### PR TITLE
redisのkv構造をちゃんとした

### DIFF
--- a/VIBES/plan/20260213-1-プロテクト機能Redisキー設計変更.md
+++ b/VIBES/plan/20260213-1-プロテクト機能Redisキー設計変更.md
@@ -1,0 +1,510 @@
+# プロテクト機能 Redisキー設計変更
+
+## 概要
+
+現在のプロテクト機能で使用しているRedisのキー設計を、拡張性と保守性を考慮した設計に変更する。
+
+## 目的
+
+1. **拡張性の確保**: 将来的に `members[]`といった付加情報や, `created_at` などのメタデータを追加できる構造にする
+2. **命名規則の統一**: プロジェクト全体で一貫したRedisキー命名規則を確立する
+3. **競合の回避**: 赤チームと青チームのデータが独立したキーで管理され、同時更新の競合を回避する
+4. **データ型の明確化**: 文字列からJSONオブジェクトへ変更し、型安全性を向上させる
+
+## 変更内容
+
+### 1. Redisキー設計の変更
+
+#### 現在のキー設計
+
+```text
+protect:${matchId}:red_team   → チャンピオン名の文字列
+protect:${matchId}:blue_team  → チャンピオン名の文字列
+```
+
+#### 新しいキー設計
+
+```text
+lol:matches:${matchId}:red_team   → JSONオブジェクト
+lol:matches:${matchId}:blue_team  → JSONオブジェクト
+lol:matches:${matchId}:meta       → JSONオブジェクト
+```
+
+**命名規則**: `{namespace}:{resource_type}:{resource_id}:{attribute}`
+
+- `lol`: プロジェクト名（namespace）
+- `matches`: リソースタイプ
+- `${matchId}`: リソースID（UUID v4）
+- `red_team` / `blue_team` / `meta`: 属性（サブリソース）
+
+### 2. データ構造の変更
+
+#### 新しいデータ構造
+
+**赤チームデータ**: `lol:matches:${matchId}:red_team`
+
+```typescript
+{
+  protection_champions: string,  // 例: "モルガナ、メル"
+  updated_at: string             // ISO 8601形式: "2026-02-13T12:34:56.789Z"
+  // 将来実装: memberRoles: { top: string, jg: string, mid: string, adc: string, sup: string }
+}
+```
+
+**青チームデータ**: `lol:matches:${matchId}:blue_team`
+
+```typescript
+{
+  protection_champions: string,  // 例: "ヴェルコズ、ザック"
+  updated_at: string             // ISO 8601形式: "2026-02-13T12:34:56.789Z"
+  // 将来実装: memberRoles: { top: string, jg: string, mid: string, adc: string, sup: string }
+}
+```
+
+**メタデータ**: `lol:matches:${matchId}:meta`
+
+```typescript
+{
+  match_id: string,              // UUID v4
+  created_at: string,            // ISO 8601形式: "2026-02-13T12:30:00.000Z"
+  // 将来実装:
+  // members?: string[]  // 試合全体のメンバー（任意のユーザー名）
+  // status?: "waiting" | "in_progress" | "completed"
+  // winner?: "red" | "blue"
+  // draft_completed?: boolean
+}
+```
+
+### 3. TypeScript型定義の追加
+
+新規ファイル: `my-app/app/types/match.ts`
+
+```typescript
+/**
+ * プロテクト機能 - チームデータ
+ */
+export type ProtectTeamData = {
+  protection_champions: string
+  updated_at: string  // ISO 8601
+  // 将来実装: memberRoles?: { top: string; jg: string; mid: string; adc: string; sup: string }
+}
+
+/**
+ * プロテクト機能 - 試合メタデータ
+ */
+export type ProtectMatchMeta = {
+  match_id: string
+  created_at: string  // ISO 8601
+  // 将来実装: members?: string[]
+}
+
+/**
+ * Redisキー生成ヘルパー関数の型
+ */
+export type MatchKeyType = "red_team" | "blue_team" | "meta"
+```
+
+### 4. Redisキー生成ヘルパー関数の追加
+
+新規ファイル: `my-app/app/util/redisKeys.ts`
+
+```typescript
+import { MatchKeyType } from "@/app/types/match"
+
+/**
+ * プロテクト機能用のRedisキーを生成する
+ * @param matchId 試合ID（UUID v4）
+ * @param keyType キータイプ（red_team, blue_team, meta）
+ * @returns Redisキー（例: "lol:matches:abc123:red_team"）
+ */
+export const getMatchKey = (matchId: string, keyType: MatchKeyType): string => {
+  return `lol:matches:${matchId}:${keyType}`
+}
+
+/**
+ * プロテクト機能用のRedisキープレフィックスを生成する
+ * @param matchId 試合ID（UUID v4）
+ * @returns Redisキープレフィックス（例: "lol:matches:abc123:"）
+ */
+export const getMatchKeyPrefix = (matchId: string): string => {
+  return `lol:matches:${matchId}:`
+}
+```
+
+### 5. Redis一括取得関数の追加
+
+`my-app/app/libs/redis/redis.ts` に以下の関数を追加：
+
+```typescript
+/**
+ * パターンマッチングでキーを検索する（SCAN使用）
+ * @param pattern パターン（例: "lol:matches:abc123:*"）
+ * @returns マッチしたキーの配列
+ */
+export const redisScanKeys = async (pattern: string): Promise<string[]> => {
+  const client = await getRedisClient()
+  const keys: string[] = []
+  let cursor = 0
+
+  do {
+    const result = await client.scan(cursor, {
+      MATCH: pattern,
+      COUNT: 100
+    })
+    cursor = result.cursor
+    keys.push(...result.keys)
+  } while (cursor !== 0)
+
+  return keys
+}
+
+/**
+ * 複数のキーを一括取得する（MGET使用）
+ * @param keys キーの配列
+ * @returns 値の配列（nullを含む可能性あり）
+ */
+export const redisMGet = async <T = string>(keys: string[]): Promise<(T | null)[]> => {
+  if (keys.length === 0) {
+    return []
+  }
+
+  const client = await getRedisClient()
+  const results = await client.mGet(keys)
+
+  return results.map((result) => {
+    if (result === null) {
+      return null
+    }
+    try {
+      return JSON.parse(result) as T
+    } catch {
+      return result as T
+    }
+  })
+}
+
+/**
+ * 試合IDに紐づく全データを一括取得する
+ * @param matchId 試合ID
+ * @returns キーと値のマップ
+ */
+export const redisGetMatchData = async (matchId: string): Promise<Map<string, unknown>> => {
+  const pattern = `lol:matches:${matchId}:*`
+  const keys = await redisScanKeys(pattern)
+
+  if (keys.length === 0) {
+    return new Map()
+  }
+
+  const values = await redisMGet(keys)
+  const dataMap = new Map<string, unknown>()
+
+  keys.forEach((key, index) => {
+    const value = values[index]
+    if (value !== null) {
+      dataMap.set(key, value)
+    }
+  })
+
+  return dataMap
+}
+```
+
+## 変更が必要なファイル
+
+### 1. 新規作成するファイル
+
+1. `my-app/app/types/match.ts` - 型定義
+2. `my-app/app/util/redisKeys.ts` - キー生成ヘルパー関数
+
+### 2. 修正が必要なファイル
+
+1. `my-app/app/libs/redis/redis.ts` - 一括取得関数の追加
+2. `my-app/app/api/discord/application-command/newProtect.ts` - メインロジック
+
+## 実装手順
+
+### Phase 1: 型定義とヘルパー関数の作成
+
+1. `my-app/app/types/match.ts` を作成
+   - `ProtectTeamData` 型を定義
+   - `ProtectMatchMeta` 型を定義
+   - `MatchKeyType` 型を定義
+
+2. `my-app/app/util/redisKeys.ts` を作成
+   - `getMatchKey()` 関数を実装
+   - `getMatchKeyPrefix()` 関数を実装
+   - テストケースを追加（将来的に）
+
+3. `my-app/app/libs/redis/redis.ts` に関数を追加
+   - `redisScanKeys()` 関数を実装（SCAN使用）
+   - `redisMGet()` 関数を実装（MGET使用）
+   - `redisGetMatchData()` 関数を実装（パターンマッチング + 一括取得）
+
+### Phase 2: newProtect.ts のリファクタリング
+
+#### 2-1. saveTeamAndCheckOther 関数の修正
+
+**現在**:
+
+```typescript
+const saveTeamAndCheckOther = async (matchId: string, team: "red" | "blue", text: string): Promise<{ otherTeamText: string | null; myText: string }> => {
+  const myKey = `protect:${matchId}:${team}_team`
+  const otherKey = `protect:${matchId}:${team === "red" ? "blue" : "red"}_team`
+
+  await redisSet(myKey, text)
+  const otherTeamText = await redisGet<string>(otherKey)
+
+  return { otherTeamText, myText: text }
+}
+```
+
+**修正後**:
+
+```typescript
+import { ProtectTeamData } from "@/app/types/match"
+import { getMatchKey } from "@/app/util/redisKeys"
+
+const saveTeamAndCheckOther = async (
+  matchId: string,
+  team: "red" | "blue",
+  text: string
+): Promise<{ otherTeamData: ProtectTeamData | null; myData: ProtectTeamData }> => {
+  const myKey = getMatchKey(matchId, `${team}_team`)
+  const otherKey = getMatchKey(matchId, team === "red" ? "blue_team" : "red_team")
+
+  // 自チームのデータを作成・保存
+  const myData: ProtectTeamData = {
+    protection_champions: text,
+    updated_at: new Date().toISOString()
+    // 将来実装: memberRoles
+  }
+  await redisSet(myKey, myData)
+
+  // 相手チームのデータを取得
+  const otherTeamData = await redisGet<ProtectTeamData>(otherKey)
+
+  return { otherTeamData, myData }
+}
+```
+
+#### 2-2. newProtectCommand 関数の修正
+
+**現在**:
+
+```typescript
+export const newProtectCommand = () => {
+  const matchId = newId()
+
+  return NextResponse.json({
+    type: 4,
+    data: {
+      content: "チームを選択してください",
+      components: createProtectComponents(matchId),
+    },
+  })
+}
+```
+
+**修正後**:
+
+```typescript
+import { ProtectMatchMeta } from "@/app/types/match"
+import { getMatchKey } from "@/app/util/redisKeys"
+
+export const newProtectCommand = async () => {
+  const matchId = newId()
+
+  // メタデータを作成・保存
+  const meta: ProtectMatchMeta = {
+    match_id: matchId,
+    created_at: new Date().toISOString()
+  }
+  await redisSet(getMatchKey(matchId, "meta"), meta)
+
+  return NextResponse.json({
+    type: 4,
+    data: {
+      content: "チームを選択してください",
+      components: createProtectComponents(matchId),
+    },
+  })
+}
+```
+
+#### 2-3. handleRegisterRedTeam / handleRegisterBlueTeam 関数の修正
+
+**現在**:
+
+```typescript
+export const handleRegisterRedTeam = async (matchId: string, teamText: string) => {
+  const { otherTeamText, myText } = await saveTeamAndCheckOther(matchId, "red", teamText)
+  const message = otherTeamText ? `🔵 ブルーサイド: ${otherTeamText}\n🔴 レッドサイド: ${myText}` : "🔴 レッドサイド登録完了"
+  return NextResponse.json({
+    type: 4,
+    data: { content: message },
+  })
+}
+```
+
+**修正後**:
+
+```typescript
+export const handleRegisterRedTeam = async (matchId: string, teamText: string) => {
+  const { otherTeamData, myData } = await saveTeamAndCheckOther(matchId, "red", teamText)
+  const message = otherTeamData
+    ? `🔵 ブルーサイド: ${otherTeamData.protection_champions}\n🔴 レッドサイド: ${myData.protection_champions}`
+    : "🔴 レッドサイド登録完了"
+  return NextResponse.json({
+    type: 4,
+    data: { content: message },
+  })
+}
+```
+
+同様に `handleRegisterBlueTeam` も修正
+
+#### 2-4. handleCheckRegistered 関数の修正（一括取得版）
+
+**現在**:
+
+```typescript
+export const handleCheckRegistered = async (matchId: string) => {
+  const redTeamText = await redisGet<string>(`protect:${matchId}:red_team`)
+  const blueTeamText = await redisGet<string>(`protect:${matchId}:blue_team`)
+
+  let message: string
+  if (redTeamText && blueTeamText) {
+    message = `✅ 両チーム登録済み\n🔵 ブルーサイド: ${blueTeamText}\n🔴 レッドサイド: ${redTeamText}`
+  } else if (redTeamText) {
+    message = "🔵 ブルーサイド: 未登録\n🔴 レッドサイド: 登録済み"
+  } else if (blueTeamText) {
+    message = "🔵 ブルーサイド: 登録済み\n🔴 レッドサイド: 未登録"
+  } else {
+    message = "🔵 ブルーサイド: 未登録\n🔴 レッドサイド: 未登録"
+  }
+
+  return NextResponse.json({
+    type: 4,
+    data: {
+      content: message,
+    },
+  })
+}
+```
+
+**修正後（前方一致で一括取得）**:
+
+```typescript
+import { ProtectTeamData } from "@/app/types/match"
+import { getMatchKey } from "@/app/util/redisKeys"
+import { redisGetMatchData } from "@/app/libs/redis/redis"
+
+export const handleCheckRegistered = async (matchId: string) => {
+  // lol:matches:${matchId}:* パターンで一括取得
+  const matchDataMap = await redisGetMatchData(matchId)
+
+  // キーからデータを取り出す
+  const redTeamKey = getMatchKey(matchId, "red_team")
+  const blueTeamKey = getMatchKey(matchId, "blue_team")
+
+  const redTeamData = matchDataMap.get(redTeamKey) as ProtectTeamData | undefined
+  const blueTeamData = matchDataMap.get(blueTeamKey) as ProtectTeamData | undefined
+
+  let message: string
+  if (redTeamData && blueTeamData) {
+    message = `✅ 両チーム登録済み\n🔵 ブルーサイド: ${blueTeamData.protection_champions}\n🔴 レッドサイド: ${redTeamData.protection_champions}`
+  } else if (redTeamData) {
+    message = "🔵 ブルーサイド: 未登録\n🔴 レッドサイド: 登録済み"
+  } else if (blueTeamData) {
+    message = "🔵 ブルーサイド: 登録済み\n🔴 レッドサイド: 未登録"
+  } else {
+    message = "🔵 ブルーサイド: 未登録\n🔴 レッドサイド: 未登録"
+  }
+
+  return NextResponse.json({
+    type: 4,
+    data: {
+      content: message,
+    },
+  })
+}
+```
+
+**最適化のポイント**:
+
+- **2回の個別クエリ → 1回のパターンマッチング + 一括取得**
+- `SCAN` + `MGET` を使用して効率的にデータを取得
+- 将来的に `meta` や他のデータも同時に取得できる拡張性
+
+### Phase 3: テストとデプロイ
+
+1. ローカル環境でテスト
+   - `/lol-new-protect` コマンドの動作確認
+   - 赤・青チーム同時登録のテスト
+   - 登録確認ボタンの動作確認
+
+2. Redisデータの確認
+   - 新しいキー形式でデータが保存されているか確認
+   - JSONオブジェクトが正しくシリアライズ/デシリアライズされているか確認
+
+3. 本番デプロイ
+   - 既存データとの互換性は考慮不要（古いキーは自然消滅）
+
+## 移行計画
+
+### 既存データの扱い
+
+- **既存データは移行しない**: 古いキー形式（`protect:*`）のデータは自然にTTLで消滅させる
+- **新規データのみ対応**: この変更以降に作成されたmatchのみ新しいキー形式で保存
+- **影響範囲**: プロテクト機能は一時的なデータ（試合ごとに生成）なので、移行スクリプトは不要
+
+### デプロイ手順
+
+1. Phase 1, 2の実装をcommit
+2. GitHub にpush
+3. Vercel で自動デプロイ
+4. Discord でコマンド動作確認
+
+## リスクと対策
+
+| リスク | 影響度 | 対策 |
+| -------- | -------- | ------ |
+| 既存の進行中の試合データが参照できなくなる | 低 | プロテクト機能は短時間（数分）で完了するため、デプロイタイミングを調整 |
+| JSONシリアライズエラー | 中 | redis.tsで既にJSON.parse/stringifyを実装済み。エラーハンドリングも実装済み |
+| キー名のタイポ | 低 | ヘルパー関数（`getMatchKey`）で一元管理 |
+| SCANコマンドのパフォーマンス | 低 | 1試合あたり3キーのみなので影響は軽微。COUNT=100で十分 |
+
+## パフォーマンス最適化の説明
+
+### SCAN + MGET の選択理由
+
+1. **KEYSコマンドを避ける**: `KEYS`はブロッキング操作のため本番環境では非推奨
+2. **SCANを使用**: イテレータベースの非ブロッキング操作で安全
+3. **MGETで一括取得**: 複数回のGETよりも効率的（ネットワークラウンドトリップを削減）
+
+### スケーラビリティ
+
+- 現状: 1試合あたり3キー（red_team, blue_team, meta）
+- 将来的に追加されるキー: draft, bans など
+- SCAN + MGETパターンは、キー数が増えても対応可能
+
+## 将来の拡張計画
+
+この新しいデータ構造により、以下の機能追加が容易になります。
+(というか、本書の実装は以下の機能のためである。)
+
+1. **メンバー管理**
+   - `lol:matches:${matchId}:meta` のvalueに以下を追加
+     `members: string[]` // 試合全体のメンバー（任意のユーザー名）
+   - `lol:matches:${matchId}:red_team` のvalueに以下を追加
+     `memberRoles: { top: string, jg: string, mid: string, adc: string, sup: string }`
+     // 各ロールに割り当てられた任意のユーザー名
+   - 同様に `lol:matches:${matchId}:blue_team` にも `memberRoles` を追加
+   - チーム編成の記録
+
+## 参考資料
+
+- [Redis Key Design Best Practices](https://www.compilenrun.com/docs/middleware/redis/redis-operations/redis-key-patterns/)
+  keyの命名やデータ構造(NoSQLはどうすべきか)みたいなのの参考になった。
+- [ISO 8601 Date and Time Format](https://en.wikipedia.org/wiki/ISO_8601)

--- a/my-app/app/api/discord/application-command/newProtect.ts
+++ b/my-app/app/api/discord/application-command/newProtect.ts
@@ -1,23 +1,39 @@
 import { CLIENT_ACTIONS } from "@/app/util/commands"
 import { newId } from "@/app/util/newId"
 import { NextResponse } from "next/server"
-import { redisSet, redisGet } from "@/app/libs/redis/redis"
+import { redisSet, redisGet, redisMGet } from "@/app/libs/redis/redis"
 import { createProtectComponents } from "@/app/util/protectMessageComponents"
+import { ProtectTeamData, ProtectMatchMeta } from "@/app/types/match"
+import { getMatchKey } from "@/app/util/redisKeys"
 
 // チームデータを保存し、相手チームのデータを確認する
-const saveTeamAndCheckOther = async (matchId: string, team: "red" | "blue", text: string): Promise<{ otherTeamText: string | null; myText: string }> => {
-  const myKey = `protect:${matchId}:${team}_team`
-  const otherKey = `protect:${matchId}:${team === "red" ? "blue" : "red"}_team`
+const saveTeamAndCheckOther = async (matchId: string, team: "red" | "blue", text: string): Promise<{ otherTeamData: ProtectTeamData | null; myData: ProtectTeamData }> => {
+  const myKey = getMatchKey(matchId, `${team}_team`)
+  const otherKey = getMatchKey(matchId, team === "red" ? "blue_team" : "red_team")
 
-  await redisSet(myKey, text)
-  const otherTeamText = await redisGet<string>(otherKey)
+  // 自チームのデータを作成・保存
+  const myData: ProtectTeamData = {
+    protection_champions: text,
+    updated_at: new Date().toISOString(),
+  }
+  await redisSet(myKey, myData)
 
-  return { otherTeamText, myText: text }
+  // 相手チームのデータを取得
+  const otherTeamData = await redisGet<ProtectTeamData>(otherKey)
+
+  return { otherTeamData, myData }
 }
 
 // コマンド初期表示
-export const newProtectCommand = () => {
+export const newProtectCommand = async () => {
   const matchId = newId()
+
+  // メタデータを作成・保存
+  const meta: ProtectMatchMeta = {
+    match_id: matchId,
+    created_at: new Date().toISOString(),
+  }
+  await redisSet(getMatchKey(matchId, "meta"), meta)
 
   return NextResponse.json({
     type: 4,
@@ -82,8 +98,8 @@ export const handleOpenModalBlueTeam = (matchId: string) => {
 
 // レッドチーム 登録処理
 export const handleRegisterRedTeam = async (matchId: string, teamText: string) => {
-  const { otherTeamText, myText } = await saveTeamAndCheckOther(matchId, "red", teamText)
-  const message = otherTeamText ? `🔵 ブルーサイド: ${otherTeamText}\n🔴 レッドサイド: ${myText}` : "🔴 レッドサイド登録完了"
+  const { otherTeamData, myData } = await saveTeamAndCheckOther(matchId, "red", teamText)
+  const message = otherTeamData ? `🔵 ブルーサイド: ${otherTeamData.protection_champions}\n🔴 レッドサイド: ${myData.protection_champions}` : "🔴 レッドサイド登録完了"
   return NextResponse.json({
     type: 4,
     data: { content: message },
@@ -92,8 +108,8 @@ export const handleRegisterRedTeam = async (matchId: string, teamText: string) =
 
 // ブルーチーム 登録処理
 export const handleRegisterBlueTeam = async (matchId: string, teamText: string) => {
-  const { otherTeamText, myText } = await saveTeamAndCheckOther(matchId, "blue", teamText)
-  const message = otherTeamText ? `🔵 ブルーサイド: ${myText}\n🔴 レッドサイド: ${otherTeamText}` : "🔵 ブルーサイド登録完了"
+  const { otherTeamData, myData } = await saveTeamAndCheckOther(matchId, "blue", teamText)
+  const message = otherTeamData ? `🔵 ブルーサイド: ${myData.protection_champions}\n🔴 レッドサイド: ${otherTeamData.protection_champions}` : "🔵 ブルーサイド登録完了"
   return NextResponse.json({
     type: 4,
     data: { content: message },
@@ -102,15 +118,21 @@ export const handleRegisterBlueTeam = async (matchId: string, teamText: string) 
 
 // 登録状況確認
 export const handleCheckRegistered = async (matchId: string) => {
-  const redTeamText = await redisGet<string>(`protect:${matchId}:red_team`)
-  const blueTeamText = await redisGet<string>(`protect:${matchId}:blue_team`)
+  const redTeamKey = getMatchKey(matchId, "red_team")
+  const blueTeamKey = getMatchKey(matchId, "blue_team")
+
+  // 一括取得（MGET使用）
+  const [redTeamData, blueTeamData] = await redisMGet<ProtectTeamData>([
+    redTeamKey,
+    blueTeamKey,
+  ])
 
   let message: string
-  if (redTeamText && blueTeamText) {
-    message = `✅ 両チーム登録済み\n🔵 ブルーサイド: ${blueTeamText}\n🔴 レッドサイド: ${redTeamText}`
-  } else if (redTeamText) {
+  if (redTeamData && blueTeamData) {
+    message = `✅ 両チーム登録済み\n🔵 ブルーサイド: ${blueTeamData.protection_champions}\n🔴 レッドサイド: ${redTeamData.protection_champions}`
+  } else if (redTeamData) {
     message = "🔵 ブルーサイド: 未登録\n🔴 レッドサイド: 登録済み"
-  } else if (blueTeamText) {
+  } else if (blueTeamData) {
     message = "🔵 ブルーサイド: 登録済み\n🔴 レッドサイド: 未登録"
   } else {
     message = "🔵 ブルーサイド: 未登録\n🔴 レッドサイド: 未登録"

--- a/my-app/app/libs/redis/redis.ts
+++ b/my-app/app/libs/redis/redis.ts
@@ -105,3 +105,32 @@ export const redisDisconnect = async (): Promise<void> => {
     redis = null
   }
 }
+
+/**
+ * 複数のキーを一括取得する（MGET使用）
+ * @param keys キーの配列
+ * @returns 値の配列（nullを含む可能性あり）
+ *
+ * NOTE: キーが不明でパターンマッチが必要な場合は、SCANコマンドを使用してキーを検索してからMGETを使用する
+ */
+export const redisMGet = async <T = string>(
+  keys: string[]
+): Promise<(T | null)[]> => {
+  if (keys.length === 0) {
+    return []
+  }
+
+  const client = await getRedisClient()
+  const results = await client.mGet(keys)
+
+  return results.map((result: string | null) => {
+    if (result === null) {
+      return null
+    }
+    try {
+      return JSON.parse(result) as T
+    } catch {
+      return result as T
+    }
+  })
+}

--- a/my-app/app/types/match.ts
+++ b/my-app/app/types/match.ts
@@ -1,0 +1,22 @@
+/**
+ * プロテクト機能 - チームデータ
+ */
+export type ProtectTeamData = {
+  protection_champions: string
+  updated_at: string // ISO 8601
+  // 将来実装: memberRoles?: { top: string; jg: string; mid: string; adc: string; sup: string }
+}
+
+/**
+ * プロテクト機能 - 試合メタデータ
+ */
+export type ProtectMatchMeta = {
+  match_id: string
+  created_at: string // ISO 8601
+  // 将来実装: members?: string[]
+}
+
+/**
+ * Redisキー生成ヘルパー関数の型
+ */
+export type MatchKeyType = "red_team" | "blue_team" | "meta"

--- a/my-app/app/util/redisKeys.ts
+++ b/my-app/app/util/redisKeys.ts
@@ -1,0 +1,20 @@
+import { MatchKeyType } from "@/app/types/match"
+
+/**
+ * プロテクト機能用のRedisキーを生成する
+ * @param matchId 試合ID（UUID v4）
+ * @param keyType キータイプ（red_team, blue_team, meta）
+ * @returns Redisキー（例: "lol:matches:abc123:red_team"）
+ */
+export const getMatchKey = (matchId: string, keyType: MatchKeyType): string => {
+  return `lol:matches:${matchId}:${keyType}`
+}
+
+/**
+ * プロテクト機能用のRedisキープレフィックスを生成する
+ * @param matchId 試合ID（UUID v4）
+ * @returns Redisキープレフィックス（例: "lol:matches:abc123:"）
+ */
+export const getMatchKeyPrefix = (matchId: string): string => {
+  return `lol:matches:${matchId}:`
+}


### PR DESCRIPTION
- close #4 
- close #12

[Redis Key Design Best Practices](https://www.compilenrun.com/docs/middleware/redis/redis-operations/redis-key-patterns/)
を参考にしてkeyの命名やデータ構造(NoSQLはどうすべきか)みたいなのを構築し直した。

これにより、lol以外のものやその試合に関連する他の情報…memberとかroleとか結果とか…について拡張しやすくなった。

 - `lol:matches:${matchId}:meta` 
   - id
   - `members
   - created_at
- `lol:matches:${matchId}:red_team` 
   - chammpion_protection
   - `memberRoles: { top: string, jg: string, mid: string, adc: string, sup: string }`
- `lol:matches:${matchId}:blue_team` 
   - chammpion_protection
   - `memberRoles: { top: string, jg: string, mid: string, adc: string, sup: string }`