### PR TITLE
user-mention-reactorsコマンド実装

### DIFF
--- a/VIBES/plan/20260307-1-user-mention-reactorsコマンド実装.md
+++ b/VIBES/plan/20260307-1-user-mention-reactorsコマンド実装.md
@@ -1,0 +1,159 @@
+# `/user-mention-reactors` コマンド実装
+
+## 目的
+
+リアクションをつけた全ユーザーにメンションを送る機能を実装する。
+
+## 背景
+
+### issue #56の要約
+
+Discord上で特定のメッセージにリアクションした全員にメンションを送りたい場合がある。
+
+**要件:**
+1. コマンド実行：required optionでメッセージのリンクを受け取る
+2. リアクション取得：選択されたメッセージについているリアクションを取得
+3. メッセージ投稿：embedでそのリアクションについていた人全員にメンション、メッセージ内容、created by コマンド実行者を表示
+
+## 実装計画
+
+### 1. Discord API拡張
+
+**ファイル:** `my-app/app/_server/lib/discord/api.ts`
+
+新しいAPI関数を追加：
+- `getDiscordMessage(channelId, messageId)`: メッセージ情報を取得
+- `getMessageReactions(channelId, messageId, emoji)`: 特定の絵文字のリアクションユーザーを取得
+
+### 2. ドメイン型定義
+
+**ファイル:** `my-app/app/domains/user/mentionByReaction/types.ts`
+
+```typescript
+export interface MessageLinkParsed {
+  guildId: string
+  channelId: string
+  messageId: string
+}
+
+export interface ReactionUser {
+  id: string
+  username: string
+}
+```
+
+### 3. コマンド定義の追加
+
+**ファイル:** `my-app/app/_server/util/commands.ts`
+
+```typescript
+USER: {
+  // 既存...
+  MENTION_BY_REACTION: USER_PREF + "mention-by-reaction",
+}
+```
+
+### 4. コマンド登録
+
+**ファイル:** `my-app/app/api/discord/command/register.ts`
+
+```typescript
+const mentionByReaction: DiscordBotCommand = {
+  name: COMMANDS.USER.MENTION_BY_REACTION,
+  description: "特定のメッセージに指定のリアクションをつけた人にメンションでメッセージを送れます",
+  options: [
+    {
+      name: "message_link",
+      description: "メッセージのリンク（右クリック→メッセージのリンクをコピー）",
+      type: ApplicationCommandOptionType.STRING,
+      required: true,
+    },
+  ],
+}
+```
+
+### 5. コマンド実装
+
+**ファイル:** `my-app/app/api/discord/command/user/mentionReactors.ts`
+
+#### 処理フロー
+
+1. **メッセージリンクのパース**
+   - Discord メッセージリンクの形式: `https://discord.com/channels/{guild_id}/{channel_id}/{message_id}`
+   - パース失敗時はエラーメッセージを返す
+
+2. **メッセージ情報の取得**
+   - Discord APIでメッセージ情報を取得
+   - メッセージが存在しない場合はエラー
+
+3. **リアクション情報の取得**
+   - メッセージについている全リアクションを取得
+   - 各リアクションについてユーザーリストを取得
+
+4. **Embedメッセージの作成**
+   - タイトル: "リアクションメンバー"
+   - フィールド:
+     - リアクション絵文字ごとにユーザーメンションリスト
+     - 元メッセージの内容
+   - フッター: "Created by {コマンド実行者名}"
+
+5. **メッセージ投稿**
+   - コマンドを実行したチャンネルにembedを投稿
+
+### 6. ルーティング設定
+
+**ファイル:** `my-app/app/api/discord/route.ts`
+
+```typescript
+case COMMANDS.USER.MENTION_REACTORS:
+  return mentionReactorsCommand(options || [])
+```
+
+### 7. テスト方針
+
+- メッセージリンクのパース機能
+- リアクション取得機能
+- Embed生成機能
+- エラーハンドリング（存在しないメッセージ、不正なリンク等）
+
+## 技術選定
+
+### Discord API エンドポイント
+
+- **メッセージ取得:** `GET /channels/{channel_id}/messages/{message_id}`
+  - レスポンス: メッセージオブジェクト（content, reactions含む）
+
+- **リアクションユーザー取得:** `GET /channels/{channel_id}/messages/{message_id}/reactions/{emoji}`
+  - レスポンス: ユーザーオブジェクト配列
+  - 注意: 絵文字のエンコーディング（カスタム絵文字は `name:id` 形式）
+
+### メッセージリンクのパース
+
+正規表現またはURL解析を使用：
+
+```typescript
+const messageLinkRegex = /discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)/
+```
+
+### Embedフォーマット
+
+Discord Embed形式を使用：
+
+- `embeds` 配列にembedオブジェクトを含める
+- `fields` でリアクションごとのユーザーリストを表示
+- `footer` でコマンド実行者を表示
+
+## 参考資料
+
+- [Discord API - Get Channel Message](https://discord.com/developers/docs/resources/channel#get-channel-message)
+- [Discord API - Get Reactions](https://discord.com/developers/docs/resources/channel#get-reactions)
+- [Discord API - Embed Object](https://discord.com/developers/docs/resources/channel#embed-object)
+- [Message Formatting - Discord Developer Portal](https://discord.com/developers/docs/reference#message-formatting)
+
+## 注意事項
+
+1. **権限チェック**: Bot がメッセージを取得できるチャンネルかどうか
+2. **レート制限**: Discord API のレート制限に注意
+3. **大量のリアクション**: リアクションユーザーが多い場合の対応（100件以上の場合はページネーション）
+4. **カスタム絵文字**: カスタム絵文字のエンコーディング処理
+5. **メッセージの長さ制限**: Embedのフィールド値は1024文字まで

--- a/my-app/__tests__/integration/api/discord/mentionReactors.integration.test.ts
+++ b/my-app/__tests__/integration/api/discord/mentionReactors.integration.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { POST } from "@/app/api/discord/route"
+import { createMentionReactorsCommandPayload } from "../../../mocks/discord-payloads"
+import { createDiscordRequest, parseJsonResponse } from "../../../helpers/api-test-utils"
+import { InteractionResponseType, InteractionResponseFlags } from "discord-interactions"
+import * as discordApi from "@/app/_server/lib/discord/api"
+
+// Discord API関数をモック化
+vi.mock("@/app/_server/lib/discord/api", async () => {
+  const actual = await vi.importActual("@/app/_server/lib/discord/api")
+  return {
+    ...actual,
+    getDiscordMessage: vi.fn(),
+    getAllReactionFields: vi.fn(),
+  }
+})
+
+describe("Discord API - /user-mention-reactors Command Integration Test", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("success: 正しいメッセージリンクとリアクションがある場合、Embedで返す", async () => {
+    const messageLink = "https://discord.com/channels/123456789/987654321/111222333"
+
+    // getDiscordMessageのモック
+    const mockGetDiscordMessage = vi.mocked(discordApi.getDiscordMessage)
+    mockGetDiscordMessage.mockResolvedValue({
+      id: "111222333",
+      channel_id: "987654321",
+      content: "これはテストメッセージです",
+      author: {
+        id: "author-id",
+        username: "author",
+        discriminator: "0001",
+        avatar: null,
+      },
+      timestamp: "2024-01-01T00:00:00.000Z",
+      reactions: [
+        {
+          count: 2,
+          me: false,
+          emoji: {
+            id: null,
+            name: "👍",
+          },
+        },
+      ],
+    })
+
+    // getAllReactionFieldsのモック
+    const mockGetAllReactionFields = vi.mocked(discordApi.getAllReactionFields)
+    mockGetAllReactionFields.mockResolvedValue([
+      {
+        emojiName: "👍",
+        count: 2,
+        userIds: ["user1", "user2"],
+      },
+    ])
+
+    const payload = createMentionReactorsCommandPayload(messageLink)
+    const request = createDiscordRequest(payload)
+
+    const response = await POST(request)
+    const data = await parseJsonResponse(response)
+
+    expect(response.status).toBe(200)
+    expect(data.type).toBe(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE)
+    expect(data.data.embeds).toBeDefined()
+    expect(data.data.embeds).toHaveLength(1)
+
+    const embed = data.data.embeds[0]
+    expect(embed.title).toBe("リアクションメンバー")
+    expect(embed.description).toContain("これはテストメッセージです")
+    expect(embed.fields).toHaveLength(1)
+    expect(embed.fields[0].name).toBe("👍 (2)")
+    expect(embed.fields[0].value).toBe("<@user1> <@user2>")
+    expect(embed.footer.text).toContain("Created by")
+    expect(embed.color).toBe(0x5865f2)
+
+    // API呼び出しの検証
+    expect(mockGetDiscordMessage).toHaveBeenCalledTimes(1)
+    expect(mockGetDiscordMessage).toHaveBeenCalledWith("987654321", "111222333")
+    expect(mockGetAllReactionFields).toHaveBeenCalledTimes(1)
+    expect(mockGetAllReactionFields).toHaveBeenCalledWith("987654321", "111222333", [
+      {
+        count: 2,
+        me: false,
+        emoji: {
+          id: null,
+          name: "👍",
+        },
+      },
+    ])
+  })
+
+  it("failure: 不正なメッセージリンクの場合、エラーメッセージを返す", async () => {
+    const invalidLink = "https://example.com/invalid/link"
+    const payload = createMentionReactorsCommandPayload(invalidLink)
+    const request = createDiscordRequest(payload)
+
+    const response = await POST(request)
+    const data = await parseJsonResponse(response)
+
+    expect(response.status).toBe(200)
+    expect(data.type).toBe(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE)
+    expect(data.data.content).toContain("不正なメッセージリンクです")
+    expect(data.data.flags).toBe(InteractionResponseFlags.EPHEMERAL)
+  })
+
+  it("failure: リアクションがない場合、エラーメッセージを返す", async () => {
+    const messageLink = "https://discord.com/channels/123456789/987654321/111222333"
+
+    // リアクションがないメッセージを返すモック
+    const mockGetDiscordMessage = vi.mocked(discordApi.getDiscordMessage)
+    mockGetDiscordMessage.mockResolvedValue({
+      id: "111222333",
+      channel_id: "987654321",
+      content: "リアクションなしのメッセージ",
+      author: {
+        id: "author-id",
+        username: "author",
+        discriminator: "0001",
+        avatar: null,
+      },
+      timestamp: "2024-01-01T00:00:00.000Z",
+      reactions: [],
+    })
+
+    const payload = createMentionReactorsCommandPayload(messageLink)
+    const request = createDiscordRequest(payload)
+
+    const response = await POST(request)
+    const data = await parseJsonResponse(response)
+
+    expect(response.status).toBe(200)
+    expect(data.type).toBe(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE)
+    expect(data.data.content).toContain("リアクションがありません")
+    expect(data.data.flags).toBe(InteractionResponseFlags.EPHEMERAL)
+  })
+
+  it("failure: メッセージが見つからない場合、エラーメッセージを返す", async () => {
+    const messageLink = "https://discord.com/channels/123456789/987654321/999999999"
+
+    // API エラーをモック
+    const mockGetDiscordMessage = vi.mocked(discordApi.getDiscordMessage)
+    mockGetDiscordMessage.mockRejectedValue(new Error("Message not found"))
+
+    const payload = createMentionReactorsCommandPayload(messageLink)
+    const request = createDiscordRequest(payload)
+
+    const response = await POST(request)
+    const data = await parseJsonResponse(response)
+
+    expect(response.status).toBe(200)
+    expect(data.type).toBe(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE)
+    expect(data.data.content).toContain("メッセージまたはリアクション情報の取得に失敗しました")
+    expect(data.data.flags).toBe(InteractionResponseFlags.EPHEMERAL)
+  })
+
+  it("success: カスタム絵文字のリアクションも正しく処理できる", async () => {
+    const messageLink = "https://discord.com/channels/123456789/987654321/111222333"
+
+    // カスタム絵文字のリアクションを含むメッセージ
+    const mockGetDiscordMessage = vi.mocked(discordApi.getDiscordMessage)
+    mockGetDiscordMessage.mockResolvedValue({
+      id: "111222333",
+      channel_id: "987654321",
+      content: "カスタム絵文字テスト",
+      author: {
+        id: "author-id",
+        username: "author",
+        discriminator: "0001",
+        avatar: null,
+      },
+      timestamp: "2024-01-01T00:00:00.000Z",
+      reactions: [
+        {
+          count: 1,
+          me: false,
+          emoji: {
+            id: "custom123",
+            name: "custom_emoji",
+          },
+        },
+      ],
+    })
+
+    const mockGetAllReactionFields = vi.mocked(discordApi.getAllReactionFields)
+    mockGetAllReactionFields.mockResolvedValue([
+      {
+        emojiName: "custom_emoji",
+        count: 1,
+        userIds: ["user1"],
+      },
+    ])
+
+    const payload = createMentionReactorsCommandPayload(messageLink)
+    const request = createDiscordRequest(payload)
+
+    const response = await POST(request)
+    const data = await parseJsonResponse(response)
+
+    expect(response.status).toBe(200)
+    expect(data.type).toBe(InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE)
+    expect(data.data.embeds[0].fields[0].name).toBe("custom_emoji (1)")
+    expect(data.data.embeds[0].fields[0].value).toBe("<@user1>")
+
+    // getAllReactionFieldsが正しく呼ばれたか検証
+    expect(mockGetAllReactionFields).toHaveBeenCalledWith("987654321", "111222333", [
+      {
+        count: 1,
+        me: false,
+        emoji: {
+          id: "custom123",
+          name: "custom_emoji",
+        },
+      },
+    ])
+  })
+
+  it("success: メッセージが200文字より長い場合、descriptionが省略される", async () => {
+    const messageLink = "https://discord.com/channels/123456789/987654321/111222333"
+    const longMessage = "あ".repeat(250) // 200文字を超える長いメッセージ
+
+    const mockGetDiscordMessage = vi.mocked(discordApi.getDiscordMessage)
+    mockGetDiscordMessage.mockResolvedValue({
+      id: "111222333",
+      channel_id: "987654321",
+      content: longMessage,
+      author: {
+        id: "author-id",
+        username: "author",
+        discriminator: "0001",
+        avatar: null,
+      },
+      timestamp: "2024-01-01T00:00:00.000Z",
+      reactions: [
+        {
+          count: 1,
+          me: false,
+          emoji: {
+            id: null,
+            name: "👍",
+          },
+        },
+      ],
+    })
+
+    const mockGetAllReactionFields = vi.mocked(discordApi.getAllReactionFields)
+    mockGetAllReactionFields.mockResolvedValue([
+      {
+        emojiName: "👍",
+        count: 1,
+        userIds: ["user1"],
+      },
+    ])
+
+    const payload = createMentionReactorsCommandPayload(messageLink)
+    const request = createDiscordRequest(payload)
+
+    const response = await POST(request)
+    const data = await parseJsonResponse(response)
+
+    expect(response.status).toBe(200)
+    const embed = data.data.embeds[0]
+    expect(embed.description).toContain("...")
+    expect(embed.description.length).toBeLessThanOrEqual("元メッセージ: ".length + 200 + "...".length)
+  })
+})

--- a/my-app/__tests__/mocks/discord-payloads.ts
+++ b/my-app/__tests__/mocks/discord-payloads.ts
@@ -62,6 +62,11 @@ export const createEchoCommandPayload = (text: string) => createCommandPayload(C
 export const createDevelopersTestCommandPayload = (testNumber: number = 1) => createCommandPayload(COMMANDS.DEV.TEST, [{ name: "number", value: testNumber }])
 
 /**
+ * /user-mention-reactors コマンド
+ */
+export const createMentionReactorsCommandPayload = (messageLink: string) => createCommandPayload(COMMANDS.USER.MENTION_REACTORS, [{ name: "message_link", value: messageLink }])
+
+/**
  * MESSAGE_COMPONENT インタラクション（ボタンクリック）
  */
 export const createButtonClickPayload = (customId: string, messageId: string = "test-message-id") => ({

--- a/my-app/app/_server/lib/discord/api.ts
+++ b/my-app/app/_server/lib/discord/api.ts
@@ -12,6 +12,22 @@ export interface DiscordMessageResponse {
   [key: string]: unknown
 }
 
+export interface DiscordReaction {
+  emoji: {
+    id: string | null
+    name: string | null
+  }
+  count: number
+  me: boolean
+}
+
+export interface DiscordReactor {
+  id: string
+  username: string
+  discriminator: string
+  avatar: string | null
+}
+
 export class DiscordApiError extends Error {
   constructor(
     public status: number,
@@ -100,4 +116,111 @@ export async function editDiscordMessage(channelId: string, messageId: string, c
     const errorData = await response.json().catch(() => ({}))
     throw new DiscordApiError(response.status, response.statusText, errorData)
   }
+}
+
+/**
+ * Discordのメッセージを取得する
+ * @param channelId - チャンネルID
+ * @param messageId - メッセージID
+ * @returns メッセージ情報（content, reactions等を含む）
+ */
+export async function getDiscordMessage(channelId: string, messageId: string): Promise<DiscordMessageResponse & { reactions?: DiscordReaction[] }> {
+  const url = `${DISCORD_API_BASE_URL}/channels/${channelId}/messages/${messageId}`
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new DiscordApiError(response.status, response.statusText, errorData)
+    }
+
+    const data = await response.json()
+    return data
+  } catch (error) {
+    if (error instanceof DiscordApiError) {
+      throw error
+    }
+    throw new Error(`Failed to get Discord message: ${error}`)
+  }
+}
+
+/**
+ * 特定のリアクションをつけたユーザー一覧を取得する（内部使用）
+ * @param channelId - チャンネルID
+ * @param messageId - メッセージID
+ * @param emoji - 絵文字（カスタム絵文字の場合は `name:id` 形式）
+ * @returns リアクションをつけたユーザーの配列
+ */
+async function getMessageReactions(channelId: string, messageId: string, emoji: string): Promise<DiscordReactor[]> {
+  const url = `${DISCORD_API_BASE_URL}/channels/${channelId}/messages/${messageId}/reactions/${encodeURIComponent(emoji)}`
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}))
+      throw new DiscordApiError(response.status, response.statusText, errorData)
+    }
+
+    const data = await response.json()
+    return data as DiscordReactor[]
+  } catch (error) {
+    if (error instanceof DiscordApiError) {
+      throw error
+    }
+    throw new Error(`Failed to get message reactions: ${error}`)
+  }
+}
+
+/**
+ * 絵文字をエンコード用文字列に変換する
+ * @param reaction - Discord リアクション情報
+ * @returns エンコードされた絵文字文字列
+ */
+function encodeEmoji(reaction: DiscordReaction): string {
+  // カスタム絵文字の場合は `name:id` 形式
+  if (reaction.emoji.id) {
+    return `${reaction.emoji.name}:${reaction.emoji.id}`
+  }
+  // 通常の絵文字の場合はそのまま
+  return reaction.emoji.name || ""
+}
+
+/**
+ * メッセージの全リアクションについて、ユーザー情報を並列取得する
+ * @param channelId - チャンネルID
+ * @param messageId - メッセージID
+ * @param reactions - リアクション配列
+ * @returns リアクションフィールドデータの配列
+ */
+export async function getAllReactionFields(
+  channelId: string,
+  messageId: string,
+  reactions: DiscordReaction[],
+): Promise<Array<{ emojiName: string; count: number; userIds: string[] }>> {
+  return await Promise.all(
+    reactions.map(async (reaction) => {
+      const emojiEncoded = encodeEmoji(reaction)
+      const users = await getMessageReactions(channelId, messageId, emojiEncoded)
+
+      return {
+        emojiName: reaction.emoji.name || "?",
+        count: reaction.count,
+        userIds: users.map((user) => user.id),
+      }
+    }),
+  )
 }

--- a/my-app/app/_server/lib/discord/types.ts
+++ b/my-app/app/_server/lib/discord/types.ts
@@ -41,6 +41,7 @@ export interface InteractionData {
   custom_id?: string
   components?: MessageComponentData[]
   values?: string[]
+  options?: Array<{ name: string; value: string | number | boolean }>
 }
 
 /**

--- a/my-app/app/_server/util/commands.ts
+++ b/my-app/app/_server/util/commands.ts
@@ -11,6 +11,7 @@ export const COMMANDS = {
     TIMER: USER_PREF + "timer",
     COMMON_MESSAGE: USER_PREF + "common-message",
     FEEDBACK: USER_PREF + "feedback",
+    MENTION_REACTORS: USER_PREF + "mention-reactors",
   },
   FIGHTING: {
     TEAM_ORDER: FIGHTING_PREF + "team-order",

--- a/my-app/app/api/discord/command/register.ts
+++ b/my-app/app/api/discord/command/register.ts
@@ -36,6 +36,19 @@ const commonMessage: DiscordBotCommand = {
   options: [],
 }
 
+const mentionByReaction: DiscordBotCommand = {
+  name: COMMANDS.USER.MENTION_REACTORS,
+  description: "特定のメッセージに指定のリアクションをつけた人にメンションでメッセージを送れます",
+  options: [
+    {
+      name: "message_link",
+      description: "メッセージのリンク（右クリック→メッセージのリンクをコピー）",
+      type: ApplicationCommandOptionType.STRING,
+      required: true,
+    },
+  ],
+}
+
 const echo: DiscordBotCommand = {
   name: COMMANDS.DEV.ECHO,
   description: "入力したテキストをbotがチャットに送信",
@@ -93,7 +106,7 @@ const fightingTeamOrder: DiscordBotCommand = {
   ],
 }
 
-const commands: DiscordBotCommand[] = [newMatch, feedback, timer, commonMessage, fightingTeamOrder, echo, test]
+const commands: DiscordBotCommand[] = [newMatch, feedback, timer, commonMessage, mentionByReaction, fightingTeamOrder, echo, test]
 
 fetch(`https://discord.com/api/v10/applications/${DISCORD_APPLICATION_ID}/commands`, {
   // POSTにすると新規登録のみで古いのは変更されない

--- a/my-app/app/api/discord/command/user/mentionReactors.ts
+++ b/my-app/app/api/discord/command/user/mentionReactors.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server"
+import { InteractionResponseType, InteractionResponseFlags } from "discord-interactions"
+import { getDiscordMessage, getAllReactionFields } from "@/app/_server/lib/discord/api"
+import { DiscordInteraction } from "@/app/_server/lib/discord/types"
+import { createReactionEmbed } from "@/app/domains/user/mentionByReaction/util/createReactionEmbed"
+import { parseMessageLink } from "@/app/domains/user/mentionByReaction/util/parseMessageLink"
+
+// コマンド初期表示
+export const mentionReactorsCommand = async (interaction: DiscordInteraction) => {
+  // オプションからメッセージリンクを取得
+  const options = interaction.data?.options as Array<{ name: string; value: string }> | undefined
+  const messageLink = options?.find((opt) => opt.name === "message_link")?.value
+
+  if (!messageLink) {
+    return NextResponse.json({
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: "メッセージリンクが指定されていません",
+        flags: InteractionResponseFlags.EPHEMERAL,
+      },
+    })
+  }
+
+  // メッセージリンクをパース
+  const parsed = parseMessageLink(messageLink)
+  if (!parsed) {
+    return NextResponse.json({
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: "不正なメッセージリンクです。Discord のメッセージを右クリックして「メッセージのリンクをコピー」で取得してください。",
+        flags: InteractionResponseFlags.EPHEMERAL,
+      },
+    })
+  }
+
+  try {
+    // メッセージ情報を取得
+    const message = await getDiscordMessage(parsed.channelId, parsed.messageId)
+
+    // リアクションがない場合
+    if (!message.reactions || message.reactions.length === 0) {
+      return NextResponse.json({
+        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        data: {
+          content: "指定されたメッセージにはリアクションがありません",
+          flags: InteractionResponseFlags.EPHEMERAL,
+        },
+      })
+    }
+
+    // コマンド実行者の情報を取得
+    const executor = interaction.member?.user?.username || interaction.user?.username || "不明"
+
+    // リアクションごとにユーザーリストを取得（並列実行）
+    const reactionFields = await getAllReactionFields(parsed.channelId, parsed.messageId, message.reactions)
+
+    // Embedメッセージを作成
+    const embed = createReactionEmbed({
+      messageContent: message.content,
+      reactionFields,
+      executor,
+    })
+
+    return NextResponse.json({
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        embeds: [embed],
+      },
+    })
+  } catch (error) {
+    console.error("Error fetching message or reactions:", error)
+    return NextResponse.json({
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: "メッセージまたはリアクション情報の取得に失敗しました。Bot に該当チャンネルへのアクセス権限があるか確認してください。",
+        flags: InteractionResponseFlags.EPHEMERAL,
+      },
+    })
+  }
+}

--- a/my-app/app/api/discord/route.ts
+++ b/my-app/app/api/discord/route.ts
@@ -5,6 +5,7 @@ import { newMatchCommand, handleCheckRegistered, handleRegisterTeam, handleOpenM
 import { feedbackCommand, handleSelectFeedbackType, handleSubmitFeedback } from "./command/user/feedback"
 import { timerCommand, handleSubmitTimer, handleOpenModalTimer } from "./command/user/timer"
 import { commonMessageCommand, handleSubmitNewCommonMessage, handleOpenModalEditCommonMessage, handleSubmitCommonMessage, handleForceEndEditingCommonMessage } from "./command/user/commonMessage"
+import { mentionReactorsCommand } from "./command/user/mentionReactors"
 import { handleFightingTeamOrderCommand, handleOpenModalFightingTeamOrder, handleFightingRegisterTeamOrder, handleFightingResetTeamOrder } from "./command/fighting-game/teamOrder"
 import { CLIENT_ACTIONS, COMMANDS } from "@/app/_server/util/commands"
 import { developersTestCommand } from "./command/dev/developers-test"
@@ -61,6 +62,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           return feedbackCommand()
         case COMMANDS.USER.COMMON_MESSAGE:
           return commonMessageCommand()
+        case COMMANDS.USER.MENTION_REACTORS:
+          return mentionReactorsCommand(interaction)
         case COMMANDS.FIGHTING.TEAM_ORDER:
           return handleFightingTeamOrderCommand(options || [])
         case COMMANDS.DEV.ECHO:

--- a/my-app/app/domains/user/mentionByReaction/types.ts
+++ b/my-app/app/domains/user/mentionByReaction/types.ts
@@ -1,0 +1,16 @@
+export interface MessageLinkParsed {
+  guildId: string
+  channelId: string
+  messageId: string
+}
+
+export interface ReactionUser {
+  id: string
+  username: string
+}
+
+export interface ReactionFieldData {
+  emojiName: string
+  count: number
+  userIds: string[]
+}

--- a/my-app/app/domains/user/mentionByReaction/util/createReactionEmbed.test.ts
+++ b/my-app/app/domains/user/mentionByReaction/util/createReactionEmbed.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest"
+import { createReactionEmbed } from "./createReactionEmbed"
+import { ReactionFieldData } from "../types"
+
+describe("createReactionEmbed", () => {
+  it("success: リアクション情報から正しいEmbedを生成する", () => {
+    // リアクションフィールドデータ
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "👍",
+        count: 3,
+        userIds: ["user1", "user2", "user3"],
+      },
+      {
+        emojiName: "custom_emoji",
+        count: 2,
+        userIds: ["user4", "user5"],
+      },
+    ]
+
+    // Embedを生成
+    const result = createReactionEmbed({
+      messageContent: "これはテストメッセージです",
+      reactionFields,
+      executor: "TestUser",
+    })
+
+    // 結果の検証
+    expect(result).toEqual({
+      title: "リアクションメンバー",
+      description: "元メッセージ: これはテストメッセージです",
+      fields: [
+        {
+          name: "👍 (3)",
+          value: "<@user1> <@user2> <@user3>",
+          inline: false,
+        },
+        {
+          name: "custom_emoji (2)",
+          value: "<@user4> <@user5>",
+          inline: false,
+        },
+      ],
+      footer: {
+        text: "Created by TestUser",
+      },
+      color: 0x5865f2,
+    })
+  })
+
+  it("success: メッセージが200文字より長い場合、descriptionが省略される", () => {
+    const longMessage = "あ".repeat(250) // 200文字を超える長いメッセージ
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "👍",
+        count: 1,
+        userIds: ["user1"],
+      },
+    ]
+
+    const result = createReactionEmbed({
+      messageContent: longMessage,
+      reactionFields,
+      executor: "TestUser",
+    })
+
+    expect(result.description).toContain("...")
+    expect(result.description!.length).toBeLessThanOrEqual("元メッセージ: ".length + 200 + "...".length)
+  })
+
+  it("success: メンション文字列が1024文字を超える場合、省略される", () => {
+    // 100ユーザー分のID（各ユーザーのメンションは約22文字 = `<@user_123456789012345678>`）
+    const userIds = Array.from({ length: 100 }, (_, i) => `user_${i.toString().padStart(18, "0")}`)
+
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "🔥",
+        count: 100,
+        userIds,
+      },
+    ]
+
+    const result = createReactionEmbed({
+      messageContent: "人気のメッセージ",
+      reactionFields,
+      executor: "TestUser",
+    })
+
+    expect(result.fields![0].value).toContain("...")
+    expect(result.fields![0].value.length).toBeLessThanOrEqual(1024)
+  })
+
+  it("success: ユーザーIDが空の場合、「なし」が表示される", () => {
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "😢",
+        count: 0,
+        userIds: [],
+      },
+    ]
+
+    const result = createReactionEmbed({
+      messageContent: "リアクションユーザーなし",
+      reactionFields,
+      executor: "TestUser",
+    })
+
+    expect(result.fields![0].value).toBe("なし")
+  })
+
+  it("success: 複数のリアクションフィールドが正しく処理される", () => {
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "👍",
+        count: 2,
+        userIds: ["user1", "user2"],
+      },
+      {
+        emojiName: "👎",
+        count: 1,
+        userIds: ["user3"],
+      },
+      {
+        emojiName: "❤️",
+        count: 3,
+        userIds: ["user4", "user5", "user6"],
+      },
+    ]
+
+    const result = createReactionEmbed({
+      messageContent: "複数リアクション",
+      reactionFields,
+      executor: "TestUser",
+    })
+
+    expect(result.fields).toHaveLength(3)
+    expect(result.fields![0].name).toBe("👍 (2)")
+    expect(result.fields![1].name).toBe("👎 (1)")
+    expect(result.fields![2].name).toBe("❤️ (3)")
+  })
+
+  it("success: executor名が正しくfooterに表示される", () => {
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "✅",
+        count: 1,
+        userIds: ["user1"],
+      },
+    ]
+
+    const result = createReactionEmbed({
+      messageContent: "テスト",
+      reactionFields,
+      executor: "CustomExecutorName",
+    })
+
+    expect(result.footer!.text).toBe("Created by CustomExecutorName")
+  })
+
+  it("success: メッセージ内容がちょうど200文字の場合、省略されない", () => {
+    const exactMessage = "あ".repeat(200) // ちょうど200文字
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "📝",
+        count: 1,
+        userIds: ["user1"],
+      },
+    ]
+
+    const result = createReactionEmbed({
+      messageContent: exactMessage,
+      reactionFields,
+      executor: "TestUser",
+    })
+
+    expect(result.description).not.toContain("...")
+    expect(result.description).toBe(`元メッセージ: ${exactMessage}`)
+  })
+})

--- a/my-app/app/domains/user/mentionByReaction/util/createReactionEmbed.ts
+++ b/my-app/app/domains/user/mentionByReaction/util/createReactionEmbed.ts
@@ -1,0 +1,28 @@
+import { DiscordEmbed } from "@/app/_server/lib/discord/types"
+import { ReactionFieldData } from "../types"
+import { createReactionFields } from "./createReactionFields"
+
+/**
+ * リアクションメンバー表示用のEmbedを作成する（純粋関数）
+ * @param options - Embed作成オプション
+ * @returns Discord Embed
+ */
+export const createReactionEmbed = (options: { messageContent: string; reactionFields: ReactionFieldData[]; executor: string }): DiscordEmbed => {
+  const { messageContent, reactionFields, executor } = options
+
+  // リアクション情報からEmbed Fieldを作成
+  const fields = createReactionFields(reactionFields)
+
+  // Embedメッセージを作成
+  const embed: DiscordEmbed = {
+    title: "リアクションメンバー",
+    description: `元メッセージ: ${messageContent.substring(0, 200)}${messageContent.length > 200 ? "..." : ""}`,
+    fields,
+    footer: {
+      text: `Created by ${executor}`,
+    },
+    color: 0x5865f2, // Blurple color
+  }
+
+  return embed
+}

--- a/my-app/app/domains/user/mentionByReaction/util/createReactionFields.test.ts
+++ b/my-app/app/domains/user/mentionByReaction/util/createReactionFields.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest"
+import { createReactionFields } from "./createReactionFields"
+import { ReactionFieldData } from "../types"
+
+describe("createReactionFields", () => {
+  it("success: リアクション情報から正しいEmbed Fieldを生成する", () => {
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "👍",
+        count: 3,
+        userIds: ["user1", "user2", "user3"],
+      },
+      {
+        emojiName: "custom_emoji",
+        count: 2,
+        userIds: ["user4", "user5"],
+      },
+    ]
+
+    const result = createReactionFields(reactionFields)
+
+    expect(result).toEqual([
+      {
+        name: "👍 (3)",
+        value: "<@user1> <@user2> <@user3>",
+        inline: false,
+      },
+      {
+        name: "custom_emoji (2)",
+        value: "<@user4> <@user5>",
+        inline: false,
+      },
+    ])
+  })
+
+  it("success: メンション文字列が1024文字を超える場合、省略される", () => {
+    // 100ユーザー分のID（各ユーザーのメンションは約22文字 = `<@user_123456789012345678>`）
+    const userIds = Array.from({ length: 100 }, (_, i) => `user_${i.toString().padStart(18, "0")}`)
+
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "🔥",
+        count: 100,
+        userIds,
+      },
+    ]
+
+    const result = createReactionFields(reactionFields)
+
+    expect(result[0].value).toContain("...")
+    expect(result[0].value.length).toBeLessThanOrEqual(1024)
+  })
+
+  it("success: ユーザーIDが空の場合、「なし」が表示される", () => {
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "😢",
+        count: 0,
+        userIds: [],
+      },
+    ]
+
+    const result = createReactionFields(reactionFields)
+
+    expect(result[0].value).toBe("なし")
+  })
+
+  it("success: 複数のリアクションフィールドが正しく処理される", () => {
+    const reactionFields: ReactionFieldData[] = [
+      {
+        emojiName: "👍",
+        count: 2,
+        userIds: ["user1", "user2"],
+      },
+      {
+        emojiName: "👎",
+        count: 1,
+        userIds: ["user3"],
+      },
+      {
+        emojiName: "❤️",
+        count: 3,
+        userIds: ["user4", "user5", "user6"],
+      },
+    ]
+
+    const result = createReactionFields(reactionFields)
+
+    expect(result).toHaveLength(3)
+    expect(result[0].name).toBe("👍 (2)")
+    expect(result[0].value).toBe("<@user1> <@user2>")
+    expect(result[1].name).toBe("👎 (1)")
+    expect(result[1].value).toBe("<@user3>")
+    expect(result[2].name).toBe("❤️ (3)")
+    expect(result[2].value).toBe("<@user4> <@user5> <@user6>")
+  })
+
+  it("success: 空の配列を渡した場合、空の配列を返す", () => {
+    const result = createReactionFields([])
+    expect(result).toEqual([])
+  })
+})

--- a/my-app/app/domains/user/mentionByReaction/util/createReactionFields.ts
+++ b/my-app/app/domains/user/mentionByReaction/util/createReactionFields.ts
@@ -1,0 +1,23 @@
+import { DiscordEmbedField } from "@/app/_server/lib/discord/types"
+import { ReactionFieldData } from "../types"
+
+/**
+ * リアクション情報をもとにEmbed Fieldを作成する（純粋関数）
+ * @param reactionFields - リアクションフィールドデータ配列
+ * @returns Embed Field配列
+ */
+export const createReactionFields = (reactionFields: ReactionFieldData[]): DiscordEmbedField[] => {
+  return reactionFields.map((field) => {
+    // ユーザーをメンション形式に変換
+    const mentions = field.userIds.map((userId) => `<@${userId}>`).join(" ")
+
+    // Embedフィールドは1024文字まで
+    const truncatedMentions = mentions.length > 1024 ? mentions.substring(0, 1021) + "..." : mentions
+
+    return {
+      name: `${field.emojiName} (${field.count})`,
+      value: truncatedMentions || "なし",
+      inline: false,
+    }
+  })
+}

--- a/my-app/app/domains/user/mentionByReaction/util/parseMessageLink.test.ts
+++ b/my-app/app/domains/user/mentionByReaction/util/parseMessageLink.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest"
+import { parseMessageLink } from "./parseMessageLink"
+
+describe("parseMessageLink", () => {
+  it("success: 正しいDiscordメッセージリンクをパースできる", () => {
+    const link = "https://discord.com/channels/123456789/987654321/111222333"
+    const result = parseMessageLink(link)
+
+    expect(result).toEqual({
+      guildId: "123456789",
+      channelId: "987654321",
+      messageId: "111222333",
+    })
+  })
+
+  it("success: httpでも正しくパースできる", () => {
+    const link = "http://discord.com/channels/123456789/987654321/111222333"
+    const result = parseMessageLink(link)
+
+    expect(result).toEqual({
+      guildId: "123456789",
+      channelId: "987654321",
+      messageId: "111222333",
+    })
+  })
+
+  it("success: URLの前後に文字列があってもパースできる", () => {
+    const link = "このメッセージを見て https://discord.com/channels/123456789/987654321/111222333 です"
+    const result = parseMessageLink(link)
+
+    expect(result).toEqual({
+      guildId: "123456789",
+      channelId: "987654321",
+      messageId: "111222333",
+    })
+  })
+
+  it("success: URLパラメータがあってもパースできる", () => {
+    const link = "https://discord.com/channels/123456789/987654321/111222333?some=param"
+    const result = parseMessageLink(link)
+
+    expect(result).toEqual({
+      guildId: "123456789",
+      channelId: "987654321",
+      messageId: "111222333",
+    })
+  })
+
+  it("failure: 不正なリンク形式の場合はnullを返す", () => {
+    const link = "https://discord.com/invalid/link"
+    const result = parseMessageLink(link)
+
+    expect(result).toBeNull()
+  })
+
+  it("failure: Discord以外のURLの場合はnullを返す", () => {
+    const link = "https://example.com/channels/123456789/987654321/111222333"
+    const result = parseMessageLink(link)
+
+    expect(result).toBeNull()
+  })
+
+  it("failure: 部分的に一致するが不完全なURLの場合はnullを返す", () => {
+    const link = "https://discord.com/channels/123456789/987654321"
+    const result = parseMessageLink(link)
+
+    expect(result).toBeNull()
+  })
+
+  it("failure: 空文字列の場合はnullを返す", () => {
+    const link = ""
+    const result = parseMessageLink(link)
+
+    expect(result).toBeNull()
+  })
+
+  it("failure: IDが数字以外の場合はnullを返す", () => {
+    const link = "https://discord.com/channels/abc/def/ghi"
+    const result = parseMessageLink(link)
+
+    expect(result).toBeNull()
+  })
+
+  it("failure: channelsの綴りが間違っている場合はnullを返す", () => {
+    const link = "https://discord.com/channel/123456789/987654321/111222333"
+    const result = parseMessageLink(link)
+
+    expect(result).toBeNull()
+  })
+})

--- a/my-app/app/domains/user/mentionByReaction/util/parseMessageLink.ts
+++ b/my-app/app/domains/user/mentionByReaction/util/parseMessageLink.ts
@@ -1,0 +1,21 @@
+import { MessageLinkParsed } from "@/app/domains/user/mentionByReaction/types"
+
+/**
+ * Discord メッセージリンクをパースする
+ * @param link - Discord メッセージリンク
+ * @returns パース結果、または null（不正なリンクの場合）
+ */
+export function parseMessageLink(link: string): MessageLinkParsed | null {
+  const messageLinkRegex = /discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)/
+  const match = link.match(messageLinkRegex)
+
+  if (!match) {
+    return null
+  }
+
+  return {
+    guildId: match[1],
+    channelId: match[2],
+    messageId: match[3],
+  }
+}


### PR DESCRIPTION
- 関連issue: close #56 

## 概要
issueの通り。具体例はissueに画像ｱﾘ。

> discordで良くある、○○しませんか。できる人は{絵文字}でリアクション！→特定のリアクションにした人全員にだけメンションでメッセージ投稿したい！
> を叶える

## ユーザー操作

コマンド実行：required optionでmessageのリンク
modal表示：元のメッセージのコンテント200文字、select messageにあったリアクション、textarea メッセージ
メッセージ投稿：embed でそのリアクションについてた人全員にメンション、メッセージ、 authorとしてコマンド実行した人