### PR TITLE
productionの環境変数を読み込むように指定

### DIFF
--- a/.github/workflows/register-discord-commands.yml
+++ b/.github/workflows/register-discord-commands.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   register-commands:
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- #63

にて、
```bash
Run if [ -z "$DISCORD_BOT_TOKEN" ]; then
  if [ -z "$DISCORD_BOT_TOKEN" ]; then
    echo "Error: DISCORD_BOT_TOKEN secret is not set"
    exit 1
  fi
  if [ -z "$DISCORD_APPLICATION_ID" ]; then
    echo "Error: DISCORD_APPLICATION_ID secret is not set"
    exit 1
  fi
  echo "All required secrets are configured"
  shell: /usr/bin/bash -e {0}
  env:
    DISCORD_BOT_TOKEN: 
    DISCORD_APPLICATION_ID: 
Error: DISCORD_BOT_TOKEN secret is not set
Error: Process completed with exit code 1.
```
が発生した。

これが問題だったポイ
https://docs.github.com/ja/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
> When a workflow job that references an environment runs, it creates a deployment object with the environment property set to the name of your environment. 

> A job that references an environment must follow any protection rules for the environment before running or accessing the environment's secrets. 