### PR TITLE
lol-role-rouletteコマンドの実装

### DIFF
--- a/VIBES/done/20260331-1-lol-role-rouletteコマンド実装.md
+++ b/VIBES/done/20260331-1-lol-role-rouletteコマンド実装.md
@@ -1,0 +1,211 @@
+# `/lol-role-roulette` コマンド実装
+
+## 目的
+
+LoLカスタムゲームのロール抽選をDiscord上で行えるようにする。
+参加者がリアクションで希望ロールを表明し、Bot が公平なランダム抽選を行う。
+
+## 実装計画
+
+### 1. Discord API 追加
+
+**ファイル:** `my-app/app/_server/lib/discord/api.ts`
+
+追加する関数：
+
+- `addReaction(channelId, messageId, emoji)`: リアクションを追加する
+  - `PUT /channels/{channelId}/messages/{messageId}/reactions/{emoji}/@me`
+- `deleteAllReactions(channelId, messageId)`: 全リアクションを削除する
+  - `DELETE /channels/{channelId}/messages/{messageId}/reactions`
+- `getReactionUsers(channelId, messageId, emoji)`: 特定絵文字のリアクションユーザーを取得する（既存の `getMessageReactions` を export に変更、または新関数として追加）
+
+### 2. コマンド定数追加
+
+**ファイル:** `my-app/app/_server/util/commands.ts`
+
+```typescript
+COMMANDS.LOL.ROLE_ROULETTE = LOL_PREF + "role-roulette"
+
+CLIENT_ACTIONS.LOL.ROLE_ROULETTE_START = "lol-role-roulette-start"
+CLIENT_ACTIONS.LOL.ROLE_ROULETTE_RESET = "lol-role-roulette-reset"
+```
+
+### 3. コマンド登録
+
+**ファイル:** `my-app/app/api/discord/command/register.ts`
+
+```typescript
+const roleRoulette: RESTPostAPIApplicationCommandsJSONBody = {
+  name: COMMANDS.LOL.ROLE_ROULETTE,
+  description: "LoLのロール抽選を行います",
+  options: [],
+}
+```
+
+### 4. ロール抽選アルゴリズム
+
+**ファイル:** `my-app/app/domains/lol/_server/roleRouletteRoulette.ts`
+
+#### 定数
+
+```typescript
+export const ROLE_EMOJIS = {
+  TOP:  "1️⃣",  // :one:
+  JG:   "2️⃣",  // :two:
+  MID:  "3️⃣",  // :three:
+  ADC:  "4️⃣",  // :four:
+  SUP:  "5️⃣",  // :five:
+  FILL: "*️⃣",  // :asterisk:
+} as const
+
+export const ROLE_LABELS: Record<Exclude<keyof typeof ROLE_EMOJIS, "FILL">, string> = {
+  TOP: "TOP",
+  JG:  "JG",
+  MID: "MID",
+  ADC: "ADC",
+  SUP: "SUP",
+}
+```
+
+#### 型定義
+
+```typescript
+export type RoleKey = keyof typeof ROLE_LABELS
+export type RoleAssignment = Record<RoleKey, string>  // roleKey -> userId
+
+export type RouletteResult =
+  | { ok: true; assignment: RoleAssignment; rest: string[] }
+  | { ok: false; error: string }
+```
+
+#### 抽選関数
+
+```typescript
+export function runRoleRoulette(
+  reactorsByRole: Record<RoleKey | "FILL", string[]>,  // userId[]（Botを除外済み）
+  botId: string,
+): RouletteResult
+```
+
+処理フロー:
+
+1. **Bot除外**：各ロールのリアクションユーザーから Bot ID を除外
+2. **ユニーク参加者集計**：全ロール+FILLにリアクションしたユニークユーザーIDセット
+3. **バリデーション①**：ユニーク参加者が4人以下 → `"参加希望者は5人必要です"` でエラー返却
+4. **バリデーション②**：各ロール（TOP〜SUP）について、`reactorsByRole[role] + reactorsByRole["FILL"]` が空 → `"○○ができる人がいません"` で即時エラー返却
+5. **適格性マップ構築**：各ロールに担当できるユーザー一覧 = そのロールにリアクション済み OR FILL にリアクション済み
+6. **休憩者を先に決定する（fill偏り防止）**：
+   - 全参加者をシャッフル
+   - 先頭5人を `candidates`（参加）、残りを `rest`（休憩）として仮定する
+   - fill参加者がどのロールでも埋められるため、バックトラッキングで割り当てを先に行うと fill 参加者が休憩に入りにくくなる問題を防ぐための設計
+7. **ロール割り当て（バックトラッキング）**：
+   - ロール順（TOP〜SUP）をシャッフルする
+   - シャッフル済みのロール順に、candidates から適格者を1人選びながら再帰的に割り当てを試みる
+   - 割り当てに失敗した場合は別のシャッフルで再試行（MAX_ATTEMPTS 回）
+   - 全試行失敗 → `"有効な割り当てが見つかりませんでした。役職希望の偏りを見直してください。"` でエラー返却
+8. **休憩リスト**：手順6で決定した `rest` をそのまま返す
+
+### 5. コマンド実装
+
+**ファイル:** `my-app/app/api/discord/command/lol/roleRoulette.ts`
+
+#### `roleRouletteCommand`（スラッシュコマンド受信時）
+
+処理フロー:
+
+1. `InteractionResponseType.DeferredChannelMessageWithSource`（type 5）で即時応答
+2. `unstable_after`（Next.js 15+）を使い、応答後に以下を非同期実行:
+   a. `GET /webhooks/{appId}/{token}/messages/@original` で投稿メッセージIDを取得
+   b. メッセージを「抽選開始」「リセット」ボタン付き内容に編集
+   c. 各ロール絵文字をリアクションとして順次追加（6回 PUT）
+
+メッセージ本文:
+
+```txt
+やれるロールのリアクションをしてください。
+1️⃣ TOP
+2️⃣ JG
+3️⃣ MID
+4️⃣ ADC
+5️⃣ SUP
+*️⃣ fill
+```
+
+ボタンの `custom_id`:
+
+- 抽選開始: `CLIENT_ACTIONS.LOL.ROLE_ROULETTE_START`
+- リセット: `CLIENT_ACTIONS.LOL.ROLE_ROULETTE_RESET`
+
+> **Note:** メッセージID はボタンの `custom_id` に含めない。MESSAGE_COMPONENT インタラクション受信時に `interaction.channel_id` と `interaction.message.id` から取得できるため。
+
+#### `handleRoleRouletteStart`（抽選開始ボタン押下時）
+
+処理フロー:
+
+1. `InteractionResponseType.DeferredChannelMessageWithSource`（type 5）で即時応答
+2. `unstable_after` で非同期実行:
+   a. `interaction.channel_id` と `interaction.message.id` を使い、各ロール絵文字のリアクションユーザーを取得（6回 GET）
+   b. `runRoleRoulette()` を呼び出す
+   c. エラーの場合: Ephemeral メッセージで `PATCH /webhooks/{appId}/{token}/messages/@original` に書き込む
+   d. 成功の場合: 割り当て結果をフォーマットして `PATCH` で書き込む
+
+結果フォーマット:
+
+```txt
+抽選結果：
+TOP: <@userId>
+JG: <@userId>
+MID: <@userId>
+ADC: <@userId>
+SUP: <@userId>
+休憩: [guild_member_name], [guild_member_name]  ← 5人超の場合のみ表示。休憩した人にはメンションされないように
+```
+
+#### `handleRoleRouletteReset`（リセットボタン押下時）
+
+処理フロー:
+
+1. `InteractionResponseType.DeferredUpdateMessage`（type 6）で即時応答（メッセージ変更なし）
+2. `unstable_after` で非同期実行:
+   a. `DELETE /channels/{channelId}/messages/{messageId}/reactions` で全リアクション削除
+   b. 各ロール絵文字を順次再追加（6回 PUT）
+
+### 6. ルーティング設定
+
+**ファイル:** `my-app/app/api/discord/route.ts`
+
+- `APPLICATION_COMMAND` ブロックに `COMMANDS.LOL.ROLE_ROULETTE` のケースを追加
+- `MESSAGE_COMPONENT` ブロックに `CLIENT_ACTIONS.LOL.ROLE_ROULETTE_START`、`CLIENT_ACTIONS.LOL.ROLE_ROULETTE_RESET` のケースを追加
+
+### 7. テスト方針
+
+**ファイル:** `my-app/app/domains/lol/_server/roleRouletteRoulette.test.ts`
+
+- `success:` 5人ちょうどで全員希望ロールが被らない場合に正しく割り当て
+- `success:` fill参加者が任意のロールに割り当てられる
+- `success:` 7人参加の場合、5人が割り当てられ2人が休憩に入る
+- `failure:` あるロールに人間のリアクションがない場合のエラー
+- `failure:` 参加者が4人以下の場合のエラー
+- `failure:` 参加者は5人以上だが有効な割り当てが存在しない場合のエラー
+
+## 技術選定
+
+### 非同期処理: `unstable_after`
+
+Discord Interaction は3秒以内の応答が必須。リアクションの追加・取得は複数回のAPI呼び出しが必要なため、Next.js 15+ の `unstable_after` を使い、レスポンス送信後に処理を実行する。
+
+### 絵文字のAPIエンコード
+
+Unicode 絵文字（例: `1️⃣`）はそのまま `encodeURIComponent()` でエンコードして Discord API エンドポイントのパスに埋め込む。
+
+### 抽選アルゴリズム: ランダム化バックトラッキング
+
+参加者数が最大でも数十人程度であるため、シンプルな再帰バックトラッキングで十分。
+各試行前に参加者リスト・ロール順をシャッフルすることでランダム性を担保する。
+
+## 参考資料
+
+- [Discord API - Create Reaction](https://discord.com/developers/docs/resources/message#create-reaction)
+- [Discord API - Delete All Reactions](https://discord.com/developers/docs/resources/message#delete-all-reactions)
+- [Discord API - Get Reactions](https://discord.com/developers/docs/resources/message#get-reactions)
+- [Next.js unstable_after](https://nextjs.org/docs/app/api-reference/functions/unstable_after)

--- a/VIBES/done/20260331-1-lol-role-rouletteコマンド実装.md
+++ b/VIBES/done/20260331-1-lol-role-rouletteコマンド実装.md
@@ -146,7 +146,7 @@ export function runRoleRoulette(
 2. `unstable_after` で非同期実行:
    a. `interaction.channel_id` と `interaction.message.id` を使い、各ロール絵文字のリアクションユーザーを取得（6回 GET）
    b. `runRoleRoulette()` を呼び出す
-   c. エラーの場合: Ephemeral メッセージで `PATCH /webhooks/{appId}/{token}/messages/@original` に書き込む
+   c. エラーの場合: `PATCH /webhooks/{appId}/{token}/messages/@original` に書き込む（全員に見える）
    d. 成功の場合: 割り当て結果をフォーマットして `PATCH` で書き込む
 
 結果フォーマット:

--- a/my-app/app/_server/lib/discord/api.ts
+++ b/my-app/app/_server/lib/discord/api.ts
@@ -200,6 +200,119 @@ function encodeEmoji(reaction: DiscordReaction): string {
 }
 
 /**
+ * 特定のリアクションをつけたユーザー一覧を取得する
+ * @param channelId - チャンネルID
+ * @param messageId - メッセージID
+ * @param emoji - 絵文字
+ * @returns リアクションをつけたユーザーの配列
+ */
+export async function getReactionUsers(channelId: string, messageId: string, emoji: string): Promise<DiscordReactor[]> {
+  return getMessageReactions(channelId, messageId, emoji)
+}
+
+/**
+ * メッセージにリアクションを追加する
+ * @param channelId - チャンネルID
+ * @param messageId - メッセージID
+ * @param emoji - 絵文字
+ */
+export async function addReaction(channelId: string, messageId: string, emoji: string): Promise<void> {
+  const url = `${DISCORD_API_BASE_URL}/channels/${channelId}/messages/${messageId}/reactions/${encodeURIComponent(emoji)}/@me`
+
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new DiscordApiError(response.status, response.statusText, errorData)
+  }
+}
+
+/**
+ * メッセージの全リアクションを削除する
+ * @param channelId - チャンネルID
+ * @param messageId - メッセージID
+ */
+export async function deleteAllReactions(channelId: string, messageId: string): Promise<void> {
+  const url = `${DISCORD_API_BASE_URL}/channels/${channelId}/messages/${messageId}/reactions`
+
+  const response = await fetch(url, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bot ${DISCORD_BOT_TOKEN}`,
+    },
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new DiscordApiError(response.status, response.statusText, errorData)
+  }
+}
+
+/**
+ * Webhookを通じて元のインタラクションレスポンスメッセージを取得する
+ * @param applicationId - アプリケーションID
+ * @param token - インタラクショントークン
+ * @returns 元メッセージのデータ
+ */
+export async function getWebhookOriginalMessage(applicationId: string, token: string): Promise<DiscordMessageResponse> {
+  const url = `${DISCORD_API_BASE_URL}/webhooks/${applicationId}/${token}/messages/@original`
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new DiscordApiError(response.status, response.statusText, errorData)
+  }
+
+  return response.json()
+}
+
+/**
+ * Webhookを通じて元のインタラクションレスポンスメッセージを編集する
+ * @param applicationId - アプリケーションID
+ * @param token - インタラクショントークン
+ * @param content - メッセージ本文
+ * @param components - コンポーネント配列
+ */
+export async function editWebhookOriginalMessage(
+  applicationId: string,
+  token: string,
+  content: string,
+  components?: APIActionRowComponent<APIComponentInMessageActionRow>[],
+): Promise<void> {
+  const url = `${DISCORD_API_BASE_URL}/webhooks/${applicationId}/${token}/messages/@original`
+
+  const body: DiscordMessageBody = { content }
+  if (components && components.length > 0) {
+    body.components = components
+  }
+
+  const response = await fetch(url, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new DiscordApiError(response.status, response.statusText, errorData)
+  }
+}
+
+/**
  * メッセージの全リアクションについて、ユーザー情報を並列取得する
  * @param channelId - チャンネルID
  * @param messageId - メッセージID

--- a/my-app/app/_server/util/commands.ts
+++ b/my-app/app/_server/util/commands.ts
@@ -7,6 +7,7 @@ export const COMMANDS = {
   LOL: {
     NEW_MATCH: LOL_PREF + "new-match",
     RANDOM_SIDE: LOL_PREF + "random-side",
+    ROLE_ROULETTE: LOL_PREF + "role-roulette",
   },
   USER: {
     TIMER: USER_PREF + "timer",
@@ -34,6 +35,8 @@ export const CLIENT_ACTIONS = {
     RESET_REGISTERED: "reset-registered",
     OPEN_MODAL_TIMER: "open-modal-timer",
     SUBMIT_TIMER: "submit-timer-lol-new-match",
+    ROLE_ROULETTE_START: LOL_PREF + "role-roulette-start",
+    ROLE_ROULETTE_RESET: LOL_PREF + "role-roulette-reset",
   },
   USER: {
     SELECT_FEEDBACK_TYPE: "select-feedback-type",

--- a/my-app/app/api/discord/command/lol/roleRoulette.ts
+++ b/my-app/app/api/discord/command/lol/roleRoulette.ts
@@ -1,7 +1,7 @@
 import { CLIENT_ACTIONS } from "@/app/_server/util/commands"
 import { DISCORD_APPLICATION_ID } from "@/app/_server/lib/env"
 import { addReaction, deleteAllReactions, editWebhookOriginalMessage, getReactionUsers, getWebhookOriginalMessage } from "@/app/_server/lib/discord/api"
-import { ROLE_EMOJIS, ROLE_KEYS_ORDERED, ROLE_LABELS, RoleKey, runRoleRoulette } from "@/app/domains/lol/_server/roleRoulette"
+import { ROLE_EMOJIS, ROLE_KEYS, ROLE_LABELS, RoleKey, runRoleRoulette } from "@/app/domains/lol/_server/roleRoulette"
 import { NextResponse } from "next/server"
 import { after } from "next/server"
 import { APIChatInputApplicationCommandInteraction, APIMessageComponentInteraction, ButtonStyle, ComponentType, InteractionResponseType } from "discord-api-types/v10"
@@ -106,7 +106,7 @@ export const handleRoleRouletteStart = (interaction: APIMessageComponentInteract
       }
 
       // 結果フォーマット
-      const lines = ROLE_KEYS_ORDERED.map((role: RoleKey) => `${ROLE_LABELS[role]}: <@${result.assignment[role]}>`)
+      const lines = ROLE_KEYS.map((role: RoleKey) => `${ROLE_LABELS[role]}: <@${result.assignment[role]}>`)
       if (result.rest.length > 0) {
         const restNames = result.rest.map((id) => userNameMap[id] ?? id).join(", ")
         lines.push(`休憩: ${restNames}`)

--- a/my-app/app/api/discord/command/lol/roleRoulette.ts
+++ b/my-app/app/api/discord/command/lol/roleRoulette.ts
@@ -1,0 +1,149 @@
+import { CLIENT_ACTIONS } from "@/app/_server/util/commands"
+import { DISCORD_APPLICATION_ID } from "@/app/_server/lib/env"
+import { addReaction, deleteAllReactions, editWebhookOriginalMessage, getReactionUsers, getWebhookOriginalMessage } from "@/app/_server/lib/discord/api"
+import { ROLE_EMOJIS, ROLE_KEYS_ORDERED, ROLE_LABELS, RoleKey, runRoleRoulette } from "@/app/domains/lol/_server/roleRoulette"
+import { NextResponse } from "next/server"
+import { after } from "next/server"
+import { APIChatInputApplicationCommandInteraction, APIMessageComponentInteraction, ButtonStyle, ComponentType, InteractionResponseType } from "discord-api-types/v10"
+import type { APIActionRowComponent, APIComponentInMessageActionRow } from "discord-api-types/v10"
+
+const ROULETTE_MESSAGE_CONTENT = `やれるロールのリアクションをしてください。
+1️⃣ TOP
+2️⃣ JG
+3️⃣ MID
+4️⃣ ADC
+5️⃣ SUP
+*️⃣ fill`
+
+function createRoleRouletteButtons(): APIActionRowComponent<APIComponentInMessageActionRow>[] {
+  return [
+    {
+      type: ComponentType.ActionRow,
+      components: [
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Primary,
+          label: "抽選開始",
+          custom_id: CLIENT_ACTIONS.LOL.ROLE_ROULETTE_START,
+        },
+        {
+          type: ComponentType.Button,
+          style: ButtonStyle.Secondary,
+          label: "リセット",
+          custom_id: CLIENT_ACTIONS.LOL.ROLE_ROULETTE_RESET,
+        },
+      ],
+    },
+  ]
+}
+
+// スラッシュコマンド受信時
+export const roleRouletteCommand = (interaction: APIChatInputApplicationCommandInteraction): NextResponse => {
+  const { token, application_id, channel } = interaction
+
+  after(async () => {
+    try {
+      // 元メッセージを取得（IDとchannel.idが必要）
+      const original = await getWebhookOriginalMessage(application_id, token)
+      const messageId = original.id
+      const channelId = channel?.id ?? original.channel_id
+
+      // メッセージ本文 + ボタンに編集
+      await editWebhookOriginalMessage(application_id, token, ROULETTE_MESSAGE_CONTENT, createRoleRouletteButtons())
+
+      // 各ロール絵文字をリアクションとして追加
+      for (const emoji of Object.values(ROLE_EMOJIS)) {
+        await addReaction(channelId, messageId, emoji)
+      }
+    } catch (e) {
+      console.error("roleRouletteCommand after error:", e)
+    }
+  })
+
+  return NextResponse.json({
+    type: InteractionResponseType.DeferredChannelMessageWithSource,
+  })
+}
+
+// 抽選開始ボタン押下時
+export const handleRoleRouletteStart = (interaction: APIMessageComponentInteraction): NextResponse => {
+  const channelId = interaction.channel?.id ?? ""
+  const messageId = interaction.message.id
+  const { token, application_id } = interaction
+
+  after(async () => {
+    try {
+      // 各ロール絵文字のリアクションユーザーを並列取得
+      const [topUsers, jgUsers, midUsers, adcUsers, supUsers, fillUsers] = await Promise.all([
+        getReactionUsers(channelId, messageId, ROLE_EMOJIS.TOP),
+        getReactionUsers(channelId, messageId, ROLE_EMOJIS.JG),
+        getReactionUsers(channelId, messageId, ROLE_EMOJIS.MID),
+        getReactionUsers(channelId, messageId, ROLE_EMOJIS.ADC),
+        getReactionUsers(channelId, messageId, ROLE_EMOJIS.SUP),
+        getReactionUsers(channelId, messageId, ROLE_EMOJIS.FILL),
+      ])
+
+      // userId -> username マップ構築
+      const userNameMap: Record<string, string> = {}
+      for (const user of [...topUsers, ...jgUsers, ...midUsers, ...adcUsers, ...supUsers, ...fillUsers]) {
+        userNameMap[user.id] = user.username
+      }
+
+      const reactorsByRole = {
+        TOP: topUsers.map((u) => u.id),
+        JG: jgUsers.map((u) => u.id),
+        MID: midUsers.map((u) => u.id),
+        ADC: adcUsers.map((u) => u.id),
+        SUP: supUsers.map((u) => u.id),
+        FILL: fillUsers.map((u) => u.id),
+      }
+
+      const result = runRoleRoulette(reactorsByRole, DISCORD_APPLICATION_ID)
+
+      if (!result.ok) {
+        await editWebhookOriginalMessage(application_id, token, result.error)
+        return
+      }
+
+      // 結果フォーマット
+      const lines = ROLE_KEYS_ORDERED.map((role: RoleKey) => `${ROLE_LABELS[role]}: <@${result.assignment[role]}>`)
+      if (result.rest.length > 0) {
+        const restNames = result.rest.map((id) => userNameMap[id] ?? id).join(", ")
+        lines.push(`休憩: ${restNames}`)
+      }
+
+      const content = `抽選結果：\n${lines.join("\n")}`
+      await editWebhookOriginalMessage(application_id, token, content)
+    } catch (e) {
+      console.error("handleRoleRouletteStart after error:", e)
+    }
+  })
+
+  return NextResponse.json({
+    type: InteractionResponseType.DeferredChannelMessageWithSource,
+  })
+}
+
+// リセットボタン押下時
+export const handleRoleRouletteReset = (interaction: APIMessageComponentInteraction): NextResponse => {
+  const channelId = interaction.channel?.id ?? ""
+  const messageId = interaction.message.id
+
+  after(async () => {
+    try {
+      // 全リアクション削除
+      await deleteAllReactions(channelId, messageId)
+
+      // 各ロール絵文字を再追加
+      for (const emoji of Object.values(ROLE_EMOJIS)) {
+        await addReaction(channelId, messageId, emoji)
+      }
+    } catch (e) {
+      console.error("handleRoleRouletteReset after error:", e)
+    }
+  })
+
+  return NextResponse.json({
+    type: InteractionResponseType.DeferredMessageUpdate,
+  })
+}

--- a/my-app/app/api/discord/command/register.ts
+++ b/my-app/app/api/discord/command/register.ts
@@ -111,9 +111,15 @@ const fightingTeamOrder: RESTPostAPIApplicationCommandsJSONBody = {
   ],
 }
 
+const roleRoulette: RESTPostAPIApplicationCommandsJSONBody = {
+  name: COMMANDS.LOL.ROLE_ROULETTE,
+  description: "LoLのロール抽選を行います",
+  options: [],
+}
+
 // コマンド追加/削除時はここを変更する
 const ALL_COMMANDS = {
-  lol: { newMatch, randomSide },
+  lol: { newMatch, randomSide, roleRoulette },
   user: { feedback, timer, commonMessage, mentionByReaction },
   fighting: { fightingTeamOrder },
   dev: { echo, test },

--- a/my-app/app/api/discord/route.ts
+++ b/my-app/app/api/discord/route.ts
@@ -8,6 +8,7 @@ import { timerCommand, handleSubmitTimer, handleOpenModalTimer } from "./command
 import { commonMessageCommand, handleSubmitNewCommonMessage, handleOpenModalEditCommonMessage, handleSubmitCommonMessage, handleForceEndEditingCommonMessage } from "./command/user/commonMessage"
 import { mentionReactorsCommand } from "./command/user/mentionReactors"
 import { handleFightingTeamOrderCommand, handleOpenModalFightingTeamOrder, handleFightingRegisterTeamOrder, handleFightingResetTeamOrder } from "./command/fighting-game/teamOrder"
+import { roleRouletteCommand, handleRoleRouletteStart, handleRoleRouletteReset } from "./command/lol/roleRoulette"
 import { CLIENT_ACTIONS, COMMANDS } from "@/app/_server/util/commands"
 import { developersTestCommand } from "./command/dev/developers-test"
 import { editDiscordMessage } from "@/app/_server/lib/discord/api"
@@ -77,6 +78,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           return newMatchCommand()
         case COMMANDS.LOL.RANDOM_SIDE:
           return randomSideCommand()
+        case COMMANDS.LOL.ROLE_ROULETTE:
+          return roleRouletteCommand(interaction)
         case COMMANDS.USER.TIMER:
           return timerCommand()
         case COMMANDS.USER.FEEDBACK:
@@ -143,6 +146,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
           return handleOpenModalFightingTeamOrder(matchId, 2)
         case CLIENT_ACTIONS.FIGHTING.RESET_TEAM_ORDER:
           return handleFightingResetTeamOrder(matchId)
+        case CLIENT_ACTIONS.LOL.ROLE_ROULETTE_START:
+          return handleRoleRouletteStart(interaction)
+        case CLIENT_ACTIONS.LOL.ROLE_ROULETTE_RESET:
+          return handleRoleRouletteReset(interaction)
 
         default:
           return NextResponse.json({

--- a/my-app/app/domains/lol/_server/roleRoulette.test.ts
+++ b/my-app/app/domains/lol/_server/roleRoulette.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest"
+import { runRoleRoulette } from "./roleRoulette"
+import type { RoleKey } from "./roleRoulette"
+
+const BOT_ID = "bot-id"
+
+// 全ロールに全員がリアクション済み（被りなし）の reactorsByRole を返すヘルパー
+function makeReactors(userIds: string[], roles: (RoleKey | "FILL")[]): Record<RoleKey | "FILL", string[]> {
+  return {
+    TOP: roles.includes("TOP") ? userIds : [],
+    JG: roles.includes("JG") ? userIds : [],
+    MID: roles.includes("MID") ? userIds : [],
+    ADC: roles.includes("ADC") ? userIds : [],
+    SUP: roles.includes("SUP") ? userIds : [],
+    FILL: roles.includes("FILL") ? userIds : [],
+  }
+}
+
+describe("runRoleRoulette", () => {
+  it("success: 5人ちょうどで全員希望ロールが被らない場合に正しく割り当て", () => {
+    const reactorsByRole = {
+      TOP: ["u1"],
+      JG: ["u2"],
+      MID: ["u3"],
+      ADC: ["u4"],
+      SUP: ["u5"],
+      FILL: [],
+    }
+    const result = runRoleRoulette(reactorsByRole, BOT_ID)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    // 全ロールに1人ずつ割り当てられている
+    expect(Object.keys(result.assignment)).toHaveLength(5)
+    expect(result.assignment.TOP).toBe("u1")
+    expect(result.assignment.JG).toBe("u2")
+    expect(result.assignment.MID).toBe("u3")
+    expect(result.assignment.ADC).toBe("u4")
+    expect(result.assignment.SUP).toBe("u5")
+    expect(result.rest).toHaveLength(0)
+  })
+
+  it("success: fill参加者が任意のロールに割り当てられる", () => {
+    const reactorsByRole = {
+      TOP: ["u1"],
+      JG: ["u2"],
+      MID: ["u3"],
+      ADC: ["u4"],
+      SUP: [],
+      FILL: ["u5"], // u5はFILLのみリアクション → SUPに割り当てられるはず
+    }
+    const result = runRoleRoulette(reactorsByRole, BOT_ID)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    expect(result.assignment.SUP).toBe("u5")
+    expect(result.rest).toHaveLength(0)
+  })
+
+  it("success: 7人参加の場合、5人が割り当てられ2人が休憩に入る", () => {
+    // 全員が全ロールOK
+    const users = ["u1", "u2", "u3", "u4", "u5", "u6", "u7"]
+    const reactorsByRole = makeReactors(users, ["TOP", "JG", "MID", "ADC", "SUP"])
+
+    const result = runRoleRoulette(reactorsByRole, BOT_ID)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    // 5人が各ロールに割り当てられ、2人が休憩
+    expect(Object.keys(result.assignment)).toHaveLength(5)
+    const assignedIds = new Set(Object.values(result.assignment))
+    expect(assignedIds.size).toBe(5)
+    expect(result.rest).toHaveLength(2)
+
+    // 割り当てと休憩が重複しない
+    for (const restId of result.rest) {
+      expect(assignedIds.has(restId)).toBe(false)
+    }
+  })
+
+  it("failure: あるロールに人間のリアクションがない場合のエラー", () => {
+    // 5人いるがSUPとFILLに誰もリアクションしていない
+    const reactorsByRole = {
+      TOP: ["u1", "u2"],
+      JG: ["u3"],
+      MID: ["u4"],
+      ADC: ["u5"],
+      SUP: [], // SUPに誰もリアクションしていない、FILLも空
+      FILL: [],
+    }
+    const result = runRoleRoulette(reactorsByRole, BOT_ID)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain("SUP")
+  })
+
+  it("failure: 参加者が4人以下の場合のエラー", () => {
+    const reactorsByRole = {
+      TOP: ["u1"],
+      JG: ["u2"],
+      MID: ["u3"],
+      ADC: ["u4"],
+      SUP: [],
+      FILL: [],
+    }
+    const result = runRoleRoulette(reactorsByRole, BOT_ID)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error).toContain("5人")
+  })
+
+  it("failure: 参加者は5人以上だが有効な割り当てが存在しない場合のエラー", () => {
+    // 5人いるが、全員TOPにしかリアクションしていない
+    const reactorsByRole = {
+      TOP: ["u1", "u2", "u3", "u4", "u5"],
+      JG: [],
+      MID: [],
+      ADC: [],
+      SUP: [],
+      FILL: [],
+    }
+    const result = runRoleRoulette(reactorsByRole, BOT_ID)
+
+    // JG/MID/ADC/SUPができる人がいない → バリデーション②でエラー
+    expect(result.ok).toBe(false)
+  })
+
+  it("success: Bot IDのリアクションが除外される", () => {
+    const reactorsByRole = {
+      TOP: [BOT_ID, "u1"],
+      JG: ["u2"],
+      MID: ["u3"],
+      ADC: ["u4"],
+      SUP: ["u5"],
+      FILL: [],
+    }
+    const result = runRoleRoulette(reactorsByRole, BOT_ID)
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+
+    // Bot IDが割り当てられていない
+    const assignedIds = Object.values(result.assignment)
+    expect(assignedIds).not.toContain(BOT_ID)
+  })
+})

--- a/my-app/app/domains/lol/_server/roleRoulette.ts
+++ b/my-app/app/domains/lol/_server/roleRoulette.ts
@@ -18,12 +18,9 @@ export const ROLE_LABELS: Record<Exclude<keyof typeof ROLE_EMOJIS, "FILL">, stri
 export type RoleKey = keyof typeof ROLE_LABELS
 export type RoleAssignment = Record<RoleKey, string> // roleKey -> userId
 
-// 結果表示順
-export const ROLE_KEYS_ORDERED: RoleKey[] = ["TOP", "JG", "MID", "ADC", "SUP"]
-
 export type RouletteResult = { ok: true; assignment: RoleAssignment; rest: string[] } | { ok: false; error: string }
 
-const ROLE_KEYS: RoleKey[] = ["TOP", "JG", "MID", "ADC", "SUP"]
+export const ROLE_KEYS: RoleKey[] = ["TOP", "JG", "MID", "ADC", "SUP"]
 const MAX_ATTEMPTS = 100
 
 function shuffle<T>(arr: T[]): T[] {

--- a/my-app/app/domains/lol/_server/roleRoulette.ts
+++ b/my-app/app/domains/lol/_server/roleRoulette.ts
@@ -1,0 +1,117 @@
+export const ROLE_EMOJIS = {
+  TOP: "1️⃣",
+  JG: "2️⃣",
+  MID: "3️⃣",
+  ADC: "4️⃣",
+  SUP: "5️⃣",
+  FILL: "*️⃣",
+} as const
+
+export const ROLE_LABELS: Record<Exclude<keyof typeof ROLE_EMOJIS, "FILL">, string> = {
+  TOP: "TOP",
+  JG: "JG",
+  MID: "MID",
+  ADC: "ADC",
+  SUP: "SUP",
+}
+
+export type RoleKey = keyof typeof ROLE_LABELS
+export type RoleAssignment = Record<RoleKey, string> // roleKey -> userId
+
+// 結果表示順
+export const ROLE_KEYS_ORDERED: RoleKey[] = ["TOP", "JG", "MID", "ADC", "SUP"]
+
+export type RouletteResult = { ok: true; assignment: RoleAssignment; rest: string[] } | { ok: false; error: string }
+
+const ROLE_KEYS: RoleKey[] = ["TOP", "JG", "MID", "ADC", "SUP"]
+const MAX_ATTEMPTS = 100
+
+function shuffle<T>(arr: T[]): T[] {
+  const result = [...arr]
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[result[i], result[j]] = [result[j], result[i]]
+  }
+  return result
+}
+
+/**
+ * ロール抽選を実行する
+ * @param reactorsByRole - ロールごとのリアクションユーザーID（Bot除外前）
+ * @param botId - 除外するBot ID
+ */
+export function runRoleRoulette(reactorsByRole: Record<RoleKey | "FILL", string[]>, botId: string): RouletteResult {
+  // 1. Bot除外
+  const cleaned: Record<RoleKey | "FILL", string[]> = {
+    TOP: reactorsByRole.TOP.filter((id) => id !== botId),
+    JG: reactorsByRole.JG.filter((id) => id !== botId),
+    MID: reactorsByRole.MID.filter((id) => id !== botId),
+    ADC: reactorsByRole.ADC.filter((id) => id !== botId),
+    SUP: reactorsByRole.SUP.filter((id) => id !== botId),
+    FILL: reactorsByRole.FILL.filter((id) => id !== botId),
+  }
+
+  // 2. ユニーク参加者集計
+  const allIds = new Set([...cleaned.TOP, ...cleaned.JG, ...cleaned.MID, ...cleaned.ADC, ...cleaned.SUP, ...cleaned.FILL])
+  const uniqueParticipants = Array.from(allIds)
+
+  // 3. バリデーション①: 参加者5人未満
+  if (uniqueParticipants.length < 5) {
+    return { ok: false, error: "参加希望者は5人必要です" }
+  }
+
+  // 4. バリデーション②: 各ロールを担当できる人がいない
+  for (const role of ROLE_KEYS) {
+    const eligible = [...new Set([...cleaned[role], ...cleaned.FILL])]
+    if (eligible.length === 0) {
+      return { ok: false, error: `${ROLE_LABELS[role]} ができる人がいません` }
+    }
+  }
+
+  // 5〜7. MAX_ATTEMPTS 回試行
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    // 6. 参加者シャッフル → 先頭5人をcandidates、残りをrest
+    const shuffled = shuffle(uniqueParticipants)
+    const candidates = shuffled.slice(0, 5)
+    const rest = shuffled.slice(5)
+    const candidateSet = new Set(candidates)
+
+    // 5. 適格性マップ構築（candidatesの中で担当できる人）
+    const eligibilityMap: Record<RoleKey, string[]> = {
+      TOP: [...new Set([...cleaned.TOP, ...cleaned.FILL])].filter((id) => candidateSet.has(id)),
+      JG: [...new Set([...cleaned.JG, ...cleaned.FILL])].filter((id) => candidateSet.has(id)),
+      MID: [...new Set([...cleaned.MID, ...cleaned.FILL])].filter((id) => candidateSet.has(id)),
+      ADC: [...new Set([...cleaned.ADC, ...cleaned.FILL])].filter((id) => candidateSet.has(id)),
+      SUP: [...new Set([...cleaned.SUP, ...cleaned.FILL])].filter((id) => candidateSet.has(id)),
+    }
+
+    // 7. バックトラッキングでロール割り当て
+    const shuffledRoles = shuffle([...ROLE_KEYS])
+    const assignment: Partial<Record<RoleKey, string>> = {}
+    const used = new Set<string>()
+
+    const backtrack = (roleIdx: number): boolean => {
+      if (roleIdx === shuffledRoles.length) return true
+      const role = shuffledRoles[roleIdx]
+      const eligible = shuffle(eligibilityMap[role].filter((id) => !used.has(id)))
+      for (const userId of eligible) {
+        assignment[role] = userId
+        used.add(userId)
+        if (backtrack(roleIdx + 1)) return true
+        delete assignment[role]
+        used.delete(userId)
+      }
+      return false
+    }
+
+    if (backtrack(0)) {
+      return {
+        ok: true,
+        assignment: assignment as RoleAssignment,
+        rest,
+      }
+    }
+  }
+
+  return { ok: false, error: "有効な割り当てが見つかりませんでした。役職希望の偏りを見直してください。" }
+}


### PR DESCRIPTION
- `/lol-role-roulette` スラッシュコマンドを追加
- ロール絵文字リアクション（TOP/JG/MID/ADC/SUP/fill）で希望表明
- 「抽選開始」ボタンでランダム化バックトラッキングによりロール割り当て
- 「リセット」ボタンでリアクションをリセット
- fill参加者の偏り防止のため参加者シャッフル後にバックトラッキング実施
- Discord API に addReaction / deleteAllReactions / getReactionUsers / getWebhookOriginalMessage / editWebhookOriginalMessage を追加

### 気を付けた点

抽選に置いて、fillの人が抽選されやすくなったり、特定ロール希望にすることで偏りが出ないようにした。
ロジック
1. 当選する5人を決める
2. 決めるロールの順番をランダムに決める
3. 抽選を開始する