### PR TITLE
feat: チーム活動スケジュール調整にヘッダー/ログインボタン/ダークモードを追加

### DIFF
--- a/my-app/app/api/discord/command/register.ts
+++ b/my-app/app/api/discord/command/register.ts
@@ -51,7 +51,7 @@ const mentionByReaction: RESTPostAPIApplicationCommandsJSONBody = {
 
 const teamScheduleLogin: RESTPostAPIApplicationCommandsJSONBody = {
   name: COMMANDS.TEAM_SCHEDULE.LOGIN,
-  description: "スクリム調整ページのログイン用リンクを発行します（本人にだけ表示）",
+  description: "チーム活動 スケジュール調整ページのログイン用リンクを発行します（本人にだけ表示）",
   options: [],
 }
 

--- a/my-app/app/api/discord/command/team-schedule/login.ts
+++ b/my-app/app/api/discord/command/team-schedule/login.ts
@@ -56,7 +56,7 @@ async function buildLoginLinkResponse(user: APIUser | undefined): Promise<NextRe
   return NextResponse.json({
     type: InteractionResponseType.ChannelMessageWithSource,
     data: {
-      content: ["🔑 スクリム調整のログイン用リンクです（他の人に教えないでください）。", "", `${url}`, "", `-# 有効期限: ${expiryMinutes}分・1回のみ有効`].join("\n"),
+      content: ["🔑 チーム活動 スケジュール調整のログイン用リンクです（他の人に教えないでください）。", "", `${url}`, "", `-# 有効期限: ${expiryMinutes}分・1回のみ有効`].join("\n"),
       flags: MessageFlags.Ephemeral,
       components: [
         {

--- a/my-app/app/lol/_components/LolHeader.tsx
+++ b/my-app/app/lol/_components/LolHeader.tsx
@@ -13,12 +13,17 @@ const NAV_LINKS = [
   { href: "/team_schedules", label: "スクリム調整" },
 ]
 
-/** ログイン中ユーザー名を右側に表示したいページから渡す（未ログイン/未指定なら非表示） */
+/**
+ * ログイン中ユーザー名を右側に表示したいページから渡す。
+ * - userName があればその名前を表示
+ * - userName が無く onLogin が渡されていれば「ログイン」ボタンを表示
+ */
 type LolHeaderProps = {
   userName?: string | null
+  onLogin?: () => void
 }
 
-export default function LolHeader({ userName }: LolHeaderProps = {}) {
+export default function LolHeader({ userName, onLogin }: LolHeaderProps = {}) {
   const [isOpen, setIsOpen] = useState(false)
   const { open } = useOverlay()
 
@@ -82,12 +87,22 @@ export default function LolHeader({ userName }: LolHeaderProps = {}) {
             LoL ツール
           </Link>
 
-          {/* ログイン中ユーザー名（指定があれば右端に表示） */}
-          {userName && (
+          {/* 右端: ログイン中はユーザー名、未ログイン時はログインボタン */}
+          {userName ? (
             <span className="ml-auto flex items-center gap-1.5 truncate text-sm text-zinc-300" title={userName}>
               <span aria-hidden="true">👤</span>
               <span className="truncate">{userName}</span>
             </span>
+          ) : (
+            onLogin && (
+              <button
+                type="button"
+                onClick={onLogin}
+                className="ml-auto rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
+              >
+                ログイン
+              </button>
+            )
           )}
         </div>
       </header>

--- a/my-app/app/lol/_components/LolHeader.tsx
+++ b/my-app/app/lol/_components/LolHeader.tsx
@@ -10,7 +10,7 @@ const NAV_LINKS = [
   { href: "/lol/role-roulette", label: "ロールルーレット" },
   { href: "/lol/opgg-multi-link", label: "LTK向け: op.gg マルチサーチリンク生成" },
   { href: "/lol/all-ranked", label: "ランク確認" },
-  { href: "/team_schedules", label: "スクリム調整" },
+  { href: "/team_schedules", label: "チーム活動 スケジュール調整" },
 ]
 
 /**

--- a/my-app/app/lol/_components/LolHeader.tsx
+++ b/my-app/app/lol/_components/LolHeader.tsx
@@ -13,7 +13,12 @@ const NAV_LINKS = [
   { href: "/team_schedules", label: "スクリム調整" },
 ]
 
-export default function LolHeader() {
+/** ログイン中ユーザー名を右側に表示したいページから渡す（未ログイン/未指定なら非表示） */
+type LolHeaderProps = {
+  userName?: string | null
+}
+
+export default function LolHeader({ userName }: LolHeaderProps = {}) {
   const [isOpen, setIsOpen] = useState(false)
   const { open } = useOverlay()
 
@@ -76,6 +81,14 @@ export default function LolHeader() {
           <Link href="/lol" className="font-bold text-lg hover:text-zinc-300 hover:opacity-70">
             LoL ツール
           </Link>
+
+          {/* ログイン中ユーザー名（指定があれば右端に表示） */}
+          {userName && (
+            <span className="ml-auto flex items-center gap-1.5 truncate text-sm text-zinc-300" title={userName}>
+              <span aria-hidden="true">👤</span>
+              <span className="truncate">{userName}</span>
+            </span>
+          )}
         </div>
       </header>
     </>

--- a/my-app/app/lol/page.tsx
+++ b/my-app/app/lol/page.tsx
@@ -21,7 +21,7 @@ export default function LolIndexPage() {
         </li>
         <li>
           <Link href="/team_schedules" className="hover:underline hover:text-zinc-400 text-zinc-100">
-            スクリム調整
+            チーム活動 スケジュール調整
           </Link>
         </li>
       </ul>

--- a/my-app/app/team_schedules/_components/ControlBar.tsx
+++ b/my-app/app/team_schedules/_components/ControlBar.tsx
@@ -12,11 +12,11 @@ const LEGEND: CellStatus[] = ["ok", "maybe", "ng", "none"]
 /** 凡例と現在の必要人数を表示するバー（必要人数の変更はチーム設定側の責務） */
 export function ControlBar({ threshold }: ControlBarProps) {
   return (
-    <div className="flex flex-wrap items-center gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm">
-      <span className="text-slate-600">
-        成立に必要な人数：<span className="font-bold text-slate-900">{threshold}人</span>
+    <div className="flex flex-wrap items-center gap-3 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm">
+      <span className="text-zinc-300">
+        成立に必要な人数：<span className="font-bold text-zinc-100">{threshold}人</span>
       </span>
-      <div className="ml-auto flex flex-wrap items-center gap-2.5 text-xs text-slate-500">
+      <div className="ml-auto flex flex-wrap items-center gap-2.5 text-xs text-zinc-400">
         {LEGEND.map((s) => {
           const style = STATUS_STYLE[s]
           return (

--- a/my-app/app/team_schedules/_components/CreateTeamModal.tsx
+++ b/my-app/app/team_schedules/_components/CreateTeamModal.tsx
@@ -40,39 +40,39 @@ export function CreateTeamModal({ onClose, onCreated }: CreateTeamModalProps) {
   }
 
   return (
-    <div className="w-[min(92vw,440px)] rounded-xl bg-white p-6 text-slate-800 shadow-xl">
-      <h2 className="text-base font-bold text-slate-900">チームを作成</h2>
+    <div className="w-[min(92vw,440px)] rounded-xl border border-zinc-700 bg-zinc-900 p-6 text-zinc-100 shadow-xl">
+      <h2 className="text-base font-bold text-zinc-100">チームを作成</h2>
 
       <div className="mt-4 flex flex-col gap-4">
         <label className="flex flex-col gap-1 text-sm">
-          <span className="font-medium text-slate-700">チーム名</span>
+          <span className="font-medium text-zinc-300">チーム名</span>
           <input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             maxLength={50}
             placeholder="例: ○○サークル Aチーム"
-            className="rounded border border-slate-300 px-2.5 py-1.5 focus:border-indigo-400 focus:outline-none"
+            className="rounded border border-zinc-600 bg-zinc-800 px-2.5 py-1.5 text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none"
           />
         </label>
 
         <label className="flex flex-col gap-1 text-sm">
-          <span className="font-medium text-slate-700">説明（任意）</span>
+          <span className="font-medium text-zinc-300">説明（任意）</span>
           <input
             type="text"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             maxLength={200}
-            className="rounded border border-slate-300 px-2.5 py-1.5 focus:border-indigo-400 focus:outline-none"
+            className="rounded border border-zinc-600 bg-zinc-800 px-2.5 py-1.5 text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none"
           />
         </label>
 
         <label className="flex flex-col gap-1 text-sm">
-          <span className="font-medium text-slate-700">活動可否の管理方法</span>
+          <span className="font-medium text-zinc-300">活動可否の管理方法</span>
           <select
             value={mode}
             onChange={(e) => setMode(e.target.value as TeamManagementMode)}
-            className="rounded border border-slate-300 bg-white px-2.5 py-1.5 focus:border-indigo-400 focus:outline-none"
+            className="rounded border border-zinc-600 bg-zinc-800 px-2.5 py-1.5 text-zinc-100 focus:border-indigo-400 focus:outline-none"
           >
             <option value="members">メンバー集計（各自が予定を入力）</option>
             <option value="team">チーム単位（管理者がまとめて入力）</option>
@@ -81,22 +81,22 @@ export function CreateTeamModal({ onClose, onCreated }: CreateTeamModalProps) {
 
         {mode === "members" && (
           <label className="flex flex-col gap-1 text-sm">
-            <span className="font-medium text-slate-700">成立に必要な人数</span>
+            <span className="font-medium text-zinc-300">成立に必要な人数</span>
             <input
               type="number"
               min={1}
               value={requiredCount}
               onChange={(e) => setRequiredCount(Math.max(1, Number(e.target.value) || 1))}
-              className="w-24 rounded border border-slate-300 px-2.5 py-1.5 focus:border-indigo-400 focus:outline-none"
+              className="w-24 rounded border border-zinc-600 bg-zinc-800 px-2.5 py-1.5 text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none"
             />
           </label>
         )}
       </div>
 
-      {error && <p className="mt-3 text-xs text-rose-600">{error}</p>}
+      {error && <p className="mt-3 text-xs text-rose-400">{error}</p>}
 
       <div className="mt-5 flex justify-end gap-2">
-        <button type="button" onClick={onClose} className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50">
+        <button type="button" onClick={onClose} className="rounded-lg border border-zinc-600 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800">
           キャンセル
         </button>
         <button

--- a/my-app/app/team_schedules/_components/InviteModal.tsx
+++ b/my-app/app/team_schedules/_components/InviteModal.tsx
@@ -23,23 +23,23 @@ export function InviteModal({ url, expiryDays, onClose }: InviteModalProps) {
   }
 
   return (
-    <div className="w-[min(92vw,460px)] rounded-xl bg-white p-6 text-slate-800 shadow-xl">
-      <h2 className="text-base font-bold text-slate-900">招待リンク</h2>
-      <p className="mt-2 text-sm leading-relaxed text-slate-600">
+    <div className="w-[min(92vw,460px)] rounded-xl border border-zinc-700 bg-zinc-900 p-6 text-zinc-100 shadow-xl">
+      <h2 className="text-base font-bold text-zinc-100">招待リンク</h2>
+      <p className="mt-2 text-sm leading-relaxed text-zinc-300">
         このリンクを渡すと、ログインした人がこのチームに参加できます。
       </p>
 
       <div className="mt-3 flex items-stretch gap-2">
-        <input readOnly value={url} className="min-w-0 flex-1 rounded border border-slate-300 bg-slate-50 px-2.5 py-1.5 text-xs text-slate-700" />
+        <input readOnly value={url} className="min-w-0 flex-1 rounded border border-zinc-600 bg-zinc-800 px-2.5 py-1.5 text-xs text-zinc-200" />
         <button type="button" onClick={handleCopy} className="shrink-0 rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500">
           {copied ? "コピーしました" : "コピー"}
         </button>
       </div>
 
-      {expiryDays > 0 && <p className="mt-2 text-xs text-slate-400">※ 有効期限: {expiryDays}日</p>}
+      {expiryDays > 0 && <p className="mt-2 text-xs text-zinc-400">※ 有効期限: {expiryDays}日</p>}
 
       <div className="mt-5 flex justify-end">
-        <button type="button" onClick={onClose} className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700">
+        <button type="button" onClick={onClose} className="rounded-lg bg-zinc-700 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-600">
           閉じる
         </button>
       </div>

--- a/my-app/app/team_schedules/_components/LoginModal.tsx
+++ b/my-app/app/team_schedules/_components/LoginModal.tsx
@@ -16,6 +16,21 @@ export function LoginModal({ onClose }: { onClose: () => void }) {
         <li>このページに戻ると、予定を編集できるようになります</li>
       </ol>
       <p className="mt-3 text-xs text-zinc-400">※ 一度ログインすれば、以降は自動でログイン状態が維持されます。</p>
+
+      <div className="mt-4 rounded-lg border border-zinc-700 bg-zinc-800/60 p-3 text-xs leading-relaxed text-zinc-300">
+        <p>
+          サーバーに bot が居ない場合は、以下のリンクから bot を導入してから{" "}
+          <code className="rounded bg-zinc-800 px-1 py-0.5">/team-schedule-login</code> を実行してください。
+        </p>
+        <a
+          href="https://discord.com/oauth2/authorize?client_id=1465767639484858450&scope=bot+applications.commands&permissions=84992"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 inline-block break-all text-indigo-400 underline hover:text-indigo-300"
+        >
+          bot をサーバーに追加する
+        </a>
+      </div>
       <div className="mt-5 flex justify-end">
         <button
           type="button"

--- a/my-app/app/team_schedules/_components/LoginModal.tsx
+++ b/my-app/app/team_schedules/_components/LoginModal.tsx
@@ -3,24 +3,24 @@
 /** Discord magic-link ログインを案内するモーダル（書き込み時に未認証なら表示） */
 export function LoginModal({ onClose }: { onClose: () => void }) {
   return (
-    <div className="w-[min(92vw,420px)] rounded-xl bg-white p-6 text-slate-800 shadow-xl">
-      <h2 className="text-base font-bold text-slate-900">ログインが必要です</h2>
-      <p className="mt-2 text-sm leading-relaxed text-slate-600">
+    <div className="w-[min(92vw,420px)] rounded-xl border border-zinc-700 bg-zinc-900 p-6 text-zinc-100 shadow-xl">
+      <h2 className="text-base font-bold text-zinc-100">ログインが必要です</h2>
+      <p className="mt-2 text-sm leading-relaxed text-zinc-300">
         予定を編集するには Discord でのログインが必要です。以下の手順でログインしてください。
       </p>
-      <ol className="mt-3 list-decimal space-y-1.5 pl-5 text-sm text-slate-700">
+      <ol className="mt-3 list-decimal space-y-1.5 pl-5 text-sm text-zinc-200">
         <li>
-          Discord で <code className="rounded bg-slate-100 px-1 py-0.5 text-[13px]">/team-schedule-login</code> を実行
+          Discord で <code className="rounded bg-zinc-800 px-1 py-0.5 text-[13px]">/team-schedule-login</code> を実行
         </li>
         <li>bot から本人にだけ届くログイン用リンクをクリック</li>
         <li>このページに戻ると、予定を編集できるようになります</li>
       </ol>
-      <p className="mt-3 text-xs text-slate-400">※ 一度ログインすれば、以降は自動でログイン状態が維持されます。</p>
+      <p className="mt-3 text-xs text-zinc-400">※ 一度ログインすれば、以降は自動でログイン状態が維持されます。</p>
       <div className="mt-5 flex justify-end">
         <button
           type="button"
           onClick={onClose}
-          className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700"
+          className="rounded-lg bg-zinc-700 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-600"
         >
           閉じる
         </button>

--- a/my-app/app/team_schedules/_components/ScheduleCell.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleCell.tsx
@@ -42,12 +42,12 @@ export function ScheduleCell({ status, note, editable, dim = false, onCycle, onN
           disabled={status === "none"}
           placeholder="時間"
           className={
-            "mt-1 w-14 rounded border border-slate-200 px-1 py-0.5 text-center text-[11px] text-slate-700 focus:border-indigo-400 focus:outline-none " +
-            (status === "none" ? "cursor-not-allowed bg-slate-50 text-slate-300 placeholder:text-slate-300" : "")
+            "mt-1 w-14 rounded border border-zinc-600 bg-zinc-800 px-1 py-0.5 text-center text-[11px] text-zinc-100 placeholder:text-zinc-500 focus:border-indigo-400 focus:outline-none " +
+            (status === "none" ? "cursor-not-allowed bg-zinc-900 text-zinc-600 placeholder:text-zinc-600" : "")
           }
         />
       ) : (
-        <div className="mt-1 h-4.5 text-[11px] leading-4.5 text-slate-500">{note || ""}</div>
+        <div className="mt-1 h-4.5 text-[11px] leading-4.5 text-zinc-400">{note || ""}</div>
       )}
     </div>
   )

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -22,13 +22,13 @@ type ScheduleGridProps = {
 
 const SIZE = { date: 76, count: 52, opponent: 70, success: 60, member: 78 }
 
-const HEADER_BASE = "border-b border-r border-slate-200 px-2 py-2 text-xs font-semibold"
+const HEADER_BASE = "border-b border-r border-zinc-700 px-2 py-2 text-xs font-semibold"
 
 /** 行の背景色（成立 > 詰み > 通常） */
 function rowBgClass(row: GridRow): string {
-  if (row.success) return "bg-emerald-50"
-  if (row.impossible) return "bg-slate-50"
-  return "bg-white"
+  if (row.success) return "bg-emerald-900/30"
+  if (row.impossible) return "bg-zinc-950"
+  return "bg-zinc-900"
 }
 
 /** ピン留めされた列の sticky スタイルを返す */
@@ -63,7 +63,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
       size: SIZE.date,
       cell: ({ row }) => {
         const d = row.original.date
-        const wkColor = d.isSunday ? "text-rose-500" : d.isSaturday ? "text-sky-600" : "text-slate-700"
+        const wkColor = d.isSunday ? "text-rose-400" : d.isSaturday ? "text-sky-400" : "text-zinc-200"
         return (
           <span className={"text-xs font-medium " + wkColor}>
             {d.label}
@@ -80,7 +80,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
       cell: ({ row }) => {
         const r = row.original
         return (
-          <span className={"text-sm font-bold " + (r.okCount >= threshold ? "text-emerald-600" : "text-slate-400")}>
+          <span className={"text-sm font-bold " + (r.okCount >= threshold ? "text-emerald-400" : "text-zinc-500")}>
             {r.okCount}
             {r.maybeCount > 0 && <span className="ml-0.5 text-[10px] font-normal text-amber-500">+{r.maybeCount}△</span>}
           </span>
@@ -108,7 +108,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
         row.original.success ? (
           <span className="inline-block rounded bg-emerald-600 px-1.5 py-0.5 text-[11px] font-bold text-white">成立</span>
         ) : (
-          <span className="text-xs text-slate-300">—</span>
+          <span className="text-xs text-zinc-600">—</span>
         ),
     }
 
@@ -140,7 +140,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
   })
 
   return (
-    <div className="overflow-auto rounded-lg border border-slate-200 bg-white">
+    <div className="overflow-auto rounded-lg border border-zinc-700 bg-zinc-900">
       <table className="border-collapse text-sm">
         <thead>
           {table.getHeaderGroups().map((hg) => (
@@ -151,7 +151,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
                 const isEditableMember = memberColumns.find((c) => c.id === col.id)?.editable
                 const isEditableOpp = opponentColumns.find((c) => `opp:${c.teamId}` === col.id)?.editable
                 const editable = isEditableMember || isEditableOpp
-                const bg = editable ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"
+                const bg = editable ? "bg-indigo-600 text-white" : "bg-zinc-800 text-zinc-300"
                 return (
                   <th
                     key={header.id}
@@ -176,11 +176,11 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
                   const pinned = col.getIsPinned() === "left"
                   const editableMember = memberColumns.find((c) => c.id === col.id)?.editable
                   // ピン留め列（日付・○数・相手・成立）は行背景を敷く。自メンバー列は編集中のみハイライト
-                  const cellBg = pinned ? bg : editableMember ? "bg-indigo-50" : ""
+                  const cellBg = pinned ? bg : editableMember ? "bg-indigo-950/40" : ""
                   return (
                     <td
                       key={cell.id}
-                      className={"border-b border-r border-slate-200 px-1.5 py-1.5 align-top text-center " + cellBg}
+                      className={"border-b border-r border-zinc-700 px-1.5 py-1.5 align-top text-center " + cellBg}
                       style={{ ...pinnedStyle(col, false), minWidth: col.getSize(), width: pinned ? col.getSize() : undefined }}
                     >
                       {flexRender(col.columnDef.cell, cell.getContext())}

--- a/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
+++ b/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
@@ -24,13 +24,13 @@ export function TeamCompareSelector({ teams, ownTeamId, opponentTeamIds, onOwnTe
   const opponentCandidates = teams.filter((t) => t.teamId !== ownTeamId)
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm">
+    <div className="flex flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm">
       <label className="flex items-center gap-2">
-        <span className="text-slate-500">自チーム</span>
+        <span className="text-zinc-400">自チーム</span>
         <select
           value={ownTeamId ?? ""}
           onChange={(e) => onOwnTeamChange(e.target.value || null)}
-          className="rounded border border-slate-300 bg-white px-2 py-1 font-medium text-slate-800 focus:border-indigo-400 focus:outline-none"
+          className="rounded border border-zinc-600 bg-zinc-800 px-2 py-1 font-medium text-zinc-100 focus:border-indigo-400 focus:outline-none"
         >
           <option value="">選択してください</option>
           {teams.map((t) => (
@@ -42,9 +42,9 @@ export function TeamCompareSelector({ teams, ownTeamId, opponentTeamIds, onOwnTe
       </label>
 
       <div className="flex flex-wrap items-center gap-2">
-        <span className="text-slate-500">相手チーム</span>
+        <span className="text-zinc-400">相手チーム</span>
         {opponentCandidates.length === 0 ? (
-          <span className="text-xs text-slate-400">候補がありません</span>
+          <span className="text-xs text-zinc-500">候補がありません</span>
         ) : (
           opponentCandidates.map((t) => {
             const checked = opponentTeamIds.includes(t.teamId)
@@ -55,7 +55,7 @@ export function TeamCompareSelector({ teams, ownTeamId, opponentTeamIds, onOwnTe
                 onClick={() => toggleOpponent(t.teamId)}
                 className={
                   "rounded-full border px-2.5 py-1 text-xs font-medium transition-colors " +
-                  (checked ? "border-amber-500 bg-amber-50 text-amber-700" : "border-slate-300 bg-white text-slate-500 hover:border-slate-400")
+                  (checked ? "border-amber-500 bg-amber-500/15 text-amber-300" : "border-zinc-600 bg-zinc-800 text-zinc-400 hover:border-zinc-500")
                 }
               >
                 {checked ? "✓ " : ""}

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -450,7 +450,7 @@ export function TeamSchedulesPage() {
       <div className="mx-auto max-w-6xl p-3 sm:p-6">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>
-            <h1 className="text-lg font-bold tracking-tight text-zinc-100">スクリム調整</h1>
+            <h1 className="text-lg font-bold tracking-tight text-zinc-100">チーム活動 スケジュール調整</h1>
             <p className="mt-0.5 text-sm text-zinc-400">必要人数そろって、相手も空いてる日を探す</p>
           </div>
           <div className="flex items-center gap-2">

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
+import LolHeader from "@/app/lol/_components/LolHeader"
 import { useOverlay } from "@/app/_client/lib/modal/ModalContext"
 import type { ScheduleEntry, ScheduleStatus, SessionUser, TeamSchedule, TeamSummary } from "@/app/_domains/teamSchedules/types"
 import {
@@ -444,19 +445,20 @@ export function TeamSchedulesPage() {
   }, [ownTeamId, opponentTeamIds, schedulesByTeam, dates, dayKeys, session])
 
   return (
-    <div className="min-h-screen bg-slate-50 p-3 text-slate-800 sm:p-6">
-      <div className="mx-auto max-w-6xl">
+    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <LolHeader userName={session?.displayName ?? null} />
+      <div className="mx-auto max-w-6xl p-3 sm:p-6">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>
-            <h1 className="text-lg font-bold tracking-tight text-slate-900">スクリム調整</h1>
-            <p className="mt-0.5 text-sm text-slate-500">必要人数そろって、相手も空いてる日を探す</p>
+            <h1 className="text-lg font-bold tracking-tight text-zinc-100">スクリム調整</h1>
+            <p className="mt-0.5 text-sm text-zinc-400">必要人数そろって、相手も空いてる日を探す</p>
           </div>
           <div className="flex items-center gap-2">
             {isOwnAdmin && (
               <button
                 type="button"
                 onClick={() => void handleInvite()}
-                className="rounded-lg border border-indigo-300 bg-white px-3 py-1.5 text-sm font-medium text-indigo-700 hover:bg-indigo-50"
+                className="rounded-lg border border-indigo-500 bg-zinc-900 px-3 py-1.5 text-sm font-medium text-indigo-300 hover:bg-zinc-800"
               >
                 招待リンクを発行
               </button>
@@ -470,7 +472,7 @@ export function TeamSchedulesPage() {
         </div>
 
         {loadError && (
-          <div className="mt-3 rounded-lg border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-700">
+          <div className="mt-3 rounded-lg border border-rose-800 bg-rose-950/50 px-3 py-2 text-xs text-rose-300">
             データの読み込みに失敗しました。時間をおいて再読み込みしてください。
           </div>
         )}
@@ -488,9 +490,9 @@ export function TeamSchedulesPage() {
 
         <div className="mt-3">
           {loading ? (
-            <p className="text-sm text-slate-400">読み込み中…</p>
+            <p className="text-sm text-zinc-400">読み込み中…</p>
           ) : !view ? (
-            <p className="rounded-lg border border-slate-200 bg-white px-4 py-8 text-center text-sm text-slate-400">
+            <p className="rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-8 text-center text-sm text-zinc-400">
               自チームを選択すると日程グリッドが表示されます。
             </p>
           ) : (
@@ -507,7 +509,7 @@ export function TeamSchedulesPage() {
           )}
         </div>
 
-        <p className="mt-3 text-xs leading-relaxed text-slate-500">
+        <p className="mt-3 text-xs leading-relaxed text-zinc-400">
           ※ セルをタップで 未記入→○→△→× を循環。○数が必要人数以上かつ相手が空いている日が「成立」。×が増えて必要人数に届かない確定の日は行を薄く表示。相手の不可セルは薄く表示。チーム単位モードのチームは管理者が1列でまとめて入力します。時間は自由記入のため、○数は時間の重なりまでは見ていません。
         </p>
       </div>

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -446,7 +446,7 @@ export function TeamSchedulesPage() {
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
-      <LolHeader userName={session?.displayName ?? null} />
+      <LolHeader userName={session?.displayName ?? null} onLogin={openLogin} />
       <div className="mx-auto max-w-6xl p-3 sm:p-6">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>

--- a/my-app/app/team_schedules/_utils.ts
+++ b/my-app/app/team_schedules/_utils.ts
@@ -14,7 +14,7 @@ export function cycleStatus(current: CellStatus): CellStatus {
 
 /** 各状態の表示設定（記号・色・ラベル） */
 export const STATUS_STYLE: Record<CellStatus, { symbol: string; className: string; label: string }> = {
-  none: { symbol: "–", className: "border border-slate-300 bg-white text-slate-300", label: "未記入" },
+  none: { symbol: "–", className: "border border-zinc-600 bg-zinc-800 text-zinc-500", label: "未記入" },
   ok: { symbol: "○", className: "bg-emerald-500 text-white", label: "参加可" },
   maybe: { symbol: "△", className: "bg-amber-400 text-white", label: "検討中" },
   ng: { symbol: "×", className: "bg-rose-400 text-white", label: "不可" },


### PR DESCRIPTION
## 概要

チーム活動 スケジュール調整ページ（`/team_schedules`）のUIを改善する。

関連PR: #95
関連Issue: #94

## 変更内容

### ヘッダーの追加
- アプリ共通の `LolHeader` をスケジュール調整ページにも表示
- ログイン中はヘッダー右端にユーザー名（`display_name`）を表示
- 未ログイン時は「ログイン」ボタンを表示し、クリックで既存の `LoginModal` を開く

### ログイン導線
- `LoginModal` に bot 導入用の OAuth authorize リンクを追記

### ダークモード化
- ページ本体・日程グリッド・セル・凡例・各モーダルを他ページと同じ zinc 系ダークモードに統一

### 機能名の変更
- 表示名を「スクリム調整」→「チーム活動 スケジュール調整」に統一（UI・トップリンク・ナビ・Discordコマンド説明/送信文言）

## 注意
- `register.ts` のコマンド説明を変更したため、Discord側への反映には本番ビルド時の自動登録、またはローカルで `npx tsx app/api/discord/command/register.ts` の実行が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)