### PR TITLE
feat: DB疎通チェックボタンとヘルスチェックAPIを追加

### DIFF
--- a/my-app/app/_server/lib/db/index.ts
+++ b/my-app/app/_server/lib/db/index.ts
@@ -16,7 +16,18 @@ import { Pool } from "pg"
 import { DATABASE_URL } from "../env"
 import * as schema from "../../../_domains/teamSchedules/_server/schema"
 
-const isNeon = DATABASE_URL.includes("neon.tech")
+export const isNeon = DATABASE_URL.includes("neon.tech")
+
+// 接続先ホスト名（疎通チェックで「Neonに繋がっているか/localhostにフォールバックしてないか」を
+// サーバーログから確認するために使う）。レスポンスには含めない。認証情報も含めない。
+// パース不能・未設定時は空文字。
+export const dbHost: string = (() => {
+  try {
+    return new URL(DATABASE_URL).hostname
+  } catch {
+    return ""
+  }
+})()
 
 // neon-http と node-postgres でクエリAPIは共通。利用側は同じ db を使える。
 // 型は片方（NeonHttpDatabase）に寄せる。2ドライバの union のままだと

--- a/my-app/app/api/web/health/db/route.ts
+++ b/my-app/app/api/web/health/db/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+import { sql } from "drizzle-orm"
+import { db, dbHost, isNeon } from "@/app/_server/lib/db"
+
+// DB疎通チェック（認証不要）
+// select 1 を投げて成否だけを返す。
+// driver（neon-http/pg）・host・レイテンシといった内部情報はレスポンスに含めず、
+// サーバーログにのみ出力する（Vercel のログで原因を追える）。
+export async function GET() {
+  const startedAt = Date.now()
+  const driver = isNeon ? "neon-http" : "pg"
+
+  try {
+    await db.execute(sql`select 1`)
+    const latencyMs = Date.now() - startedAt
+    console.log(`db health: ok driver=${driver} host=${dbHost} latency=${latencyMs}ms`)
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "unknown error"
+    console.error(`db health: error driver=${driver} host=${dbHost}: ${message}`)
+    return NextResponse.json({ ok: false }, { status: 503 })
+  }
+}

--- a/my-app/app/api/web/health/db/route.ts
+++ b/my-app/app/api/web/health/db/route.ts
@@ -16,8 +16,9 @@ export async function GET() {
     console.log(`db health: ok driver=${driver} host=${dbHost} latency=${latencyMs}ms`)
     return NextResponse.json({ ok: true })
   } catch (error) {
+    const latencyMs = Date.now() - startedAt
     const message = error instanceof Error ? error.message : "unknown error"
-    console.error(`db health: error driver=${driver} host=${dbHost}: ${message}`)
+    console.error(`db health: error driver=${driver} host=${dbHost} latency=${latencyMs}ms: ${message}`)
     return NextResponse.json({ ok: false }, { status: 503 })
   }
 }

--- a/my-app/app/team_schedules/_components/DbHealthButton.tsx
+++ b/my-app/app/team_schedules/_components/DbHealthButton.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useState } from "react"
+
+type Status = "idle" | "checking" | "ok" | "error"
+
+/**
+ * DB疎通チェック用の極小ボタン。
+ * 画面右下に常駐。通常はほぼ透明で、hoverで色が出る。未ログインでも使える。
+ * クリックで /api/web/health/db を GET し、成否（ok）をドット色で表示するだけ。
+ * driver/host などの詳細はサーバーログ側に出る。
+ */
+export function DbHealthButton() {
+  const [status, setStatus] = useState<Status>("idle")
+
+  const check = async () => {
+    setStatus("checking")
+    try {
+      const res = await fetch("/api/web/health/db", { cache: "no-store" })
+      const data = await res.json().catch(() => ({}))
+      setStatus(res.ok && data.ok ? "ok" : "error")
+    } catch {
+      setStatus("error")
+    }
+  }
+
+  const dotColor =
+    status === "ok"
+      ? "bg-emerald-500"
+      : status === "error"
+        ? "bg-rose-500"
+        : status === "checking"
+          ? "bg-amber-400"
+          : "bg-zinc-600"
+
+  const label = status === "ok" ? "DB OK" : status === "error" ? "DB NG" : status === "checking" ? "確認中" : ""
+
+  return (
+    <button
+      type="button"
+      onClick={() => void check()}
+      title="DB疎通チェック"
+      aria-label="DB疎通チェック"
+      className="fixed bottom-2 right-2 z-50 flex items-center gap-1.5 rounded-full px-2 py-1 text-[10px] text-zinc-300 opacity-15 transition hover:opacity-100"
+    >
+      <span className={`inline-block h-2 w-2 shrink-0 rounded-full ${dotColor}`} />
+      {label && <span>{label}</span>}
+    </button>
+  )
+}

--- a/my-app/app/team_schedules/_components/DbHealthButton.tsx
+++ b/my-app/app/team_schedules/_components/DbHealthButton.tsx
@@ -8,7 +8,7 @@ type Status = "idle" | "checking" | "ok" | "error"
  * DB疎通チェック用の極小ボタン。
  * 画面右下に常駐。通常はほぼ透明で、hoverで色が出る。未ログインでも使える。
  * クリックで /api/web/health/db を GET し、成否（ok）をドット色で表示するだけ。
- * driver/host などの詳細はサーバーログ側に出る。
+ * driver/host/latency などの詳細はサーバーログ側に出る。
  */
 export function DbHealthButton() {
   const [status, setStatus] = useState<Status>("idle")

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -21,6 +21,7 @@ import type { CellStatus, GridRow, ScheduleColumn } from "../_types"
 import { aggregateDay, buildDateRange, cycleStatus, indexSchedules, indexTeamStatus, summarizeTeamStatus, toCellStatus, toScheduleStatus } from "../_utils"
 import { ControlBar } from "./ControlBar"
 import { CreateTeamModal } from "./CreateTeamModal"
+import { DbHealthButton } from "./DbHealthButton"
 import { InviteModal } from "./InviteModal"
 import { LoginModal } from "./LoginModal"
 import { ScheduleGrid } from "./ScheduleGrid"
@@ -513,6 +514,7 @@ export function TeamSchedulesPage() {
           ※ セルをタップで 未記入→○→△→× を循環。○数が必要人数以上かつ相手が空いている日が「成立」。×が増えて必要人数に届かない確定の日は行を薄く表示。相手の不可セルは薄く表示。チーム単位モードのチームは管理者が1列でまとめて入力します。時間は自由記入のため、○数は時間の重なりまでは見ていません。
         </p>
       </div>
+      <DbHealthButton />
     </div>
   )
 }


### PR DESCRIPTION
## 概要

DBに疎通できているかを画面から確認できるようにする。
develop 環境で Neon に繋がらず `ECONNREFUSED 127.0.0.1:5432`（pg ドライバが localhost にフォールバック）が出た事象の切り分け用。

## 変更内容

- **`GET /api/web/health/db`（認証不要）を追加**
  - `select 1` を投げて疎通確認
  - レスポンスは成否（`{ ok }`、失敗時 503）のみ
  - `driver`（neon-http/pg）・`host`・`latency` はレスポンスに含めず、サーバーログ（Vercelログ）にのみ出力
  - 成功時・失敗時の両方で `latency` をログ出力し、接続拒否（即失敗）かタイムアウト（時間経過後の失敗）かを切り分け可能にする
- **team_schedules 画面の右下に極小の疎通チェックボタンを追加**
  - 未ログインでも使用可
  - 通常はほぼ透明、hoverで表示
  - クリックでGETし、ドット色で成否を表示（緑=OK / 赤=NG / 黄=確認中 / 灰=未確認）

## 確認

- `npx tsc --noEmit` / `npm run lint` ともにエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 関連 Issue

- #94 チームスケジュール機能！
