### PR TITLE
feat: team_roleをmaster/admin/memberの3ロールに (#98)

### DIFF
--- a/my-app/app/_domains/teamSchedules/_server/authz.ts
+++ b/my-app/app/_domains/teamSchedules/_server/authz.ts
@@ -12,7 +12,7 @@ import { and, eq } from "drizzle-orm"
 import type { NextRequest } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { discordLinks, teamMembers } from "./schema"
-import type { TeamRole } from "@/app/_domains/teamSchedules/types"
+import { hasAdminAuthority, type TeamRole } from "@/app/_domains/teamSchedules/types"
 import { getUserIdFromSession } from "./session"
 import { TEAM_SCHEDULE_CREATOR_DISCORD_IDS } from "@/app/_server/lib/env"
 
@@ -62,7 +62,13 @@ export async function getTeamRole(teamId: string, userId: string): Promise<TeamR
   return rows[0]?.teamRole ?? null
 }
 
-/** (teamId, userId) が admin ロールか */
+/** (teamId, userId) が admin 相当以上（master または admin）の管理権限を持つか */
 export async function assertTeamAdmin(teamId: string, userId: string): Promise<boolean> {
-  return (await getTeamRole(teamId, userId)) === "admin"
+  const role = await getTeamRole(teamId, userId)
+  return role !== null && hasAdminAuthority(role)
+}
+
+/** (teamId, userId) が master ロールか（master 専用操作の判定用） */
+export async function assertTeamMaster(teamId: string, userId: string): Promise<boolean> {
+  return (await getTeamRole(teamId, userId)) === "master"
 }

--- a/my-app/app/_domains/teamSchedules/_server/schema.ts
+++ b/my-app/app/_domains/teamSchedules/_server/schema.ts
@@ -11,7 +11,7 @@
 //       passwordless（Discord magic-link）が確定したら別マイグレーションで削除する。
 
 import { sql } from "drizzle-orm"
-import { pgTable, uuid, text, integer, boolean, date, timestamp, primaryKey, foreignKey, index, check } from "drizzle-orm/pg-core"
+import { pgTable, uuid, text, integer, boolean, date, timestamp, primaryKey, foreignKey, index, uniqueIndex, check } from "drizzle-orm/pg-core"
 
 // teams: チーム（自チームも相手チームも全部ここに入れる）
 export const teams = pgTable(
@@ -54,10 +54,10 @@ export const teamMembers = pgTable(
     userId: uuid("user_id")
       .notNull()
       .references(() => users.userId, { onDelete: "cascade" }),
-    // アプリ内の権限ロール（個人 / 管理者）。{enum} で TS型も絞る
-    teamRole: text("team_role", { enum: ["individual", "admin"] })
+    // アプリ内の権限ロール（master / admin / member）。権限は master ⊇ admin ⊇ member。{enum} で TS型も絞る
+    teamRole: text("team_role", { enum: ["master", "admin", "member"] })
       .notNull()
-      .default("individual"),
+      .default("member"),
     // このチームで担当できる LoL ロール（can-play の有無）。固定5種なので bool 5列
     top: boolean("top").notNull().default(false),
     jungle: boolean("jungle").notNull().default(false),
@@ -68,7 +68,10 @@ export const teamMembers = pgTable(
   },
   (t) => [
     primaryKey({ columns: [t.teamId, t.userId] }),
-    check("team_members_team_role_chk", sql`${t.teamRole} in ('individual', 'admin')`),
+    check("team_members_team_role_chk", sql`${t.teamRole} in ('master', 'admin', 'member')`),
+    // master はチームに高々1人（部分ユニークインデックス）。「必ず1人必要」のうち上限を DB で担保し、
+    // 下限（最低1人）は作成者を master にすることで成立させる（master 不在を作る操作は別途アプリ側で防ぐ）
+    uniqueIndex("uq_team_members_one_master").on(t.teamId).where(sql`${t.teamRole} = 'master'`),
     index("idx_team_members_user").on(t.userId), // 「この人の所属チーム一覧」用
   ],
 )

--- a/my-app/app/_domains/teamSchedules/types.ts
+++ b/my-app/app/_domains/teamSchedules/types.ts
@@ -8,8 +8,16 @@
 /** 予定の状態。未記入は「行が無い」状態で表現するため、ここには含めない */
 export type ScheduleStatus = "ok" | "maybe" | "ng"
 
-/** チーム内の権限ロール */
-export type TeamRole = "individual" | "admin"
+/**
+ * チーム内の権限ロール。権限は master ⊇ admin ⊇ member の包含関係。
+ * - master: チーム・admin・member・自分を管理でき、master 権限を他人に譲渡できる（チームに必ず1人）
+ * - admin:  member・チーム・自分を編集できる（複数可）
+ * - member: 自分のことだけ編集できる（複数可）
+ */
+export type TeamRole = "master" | "admin" | "member"
+
+/** admin 相当以上（master または admin）の管理権限を持つロールか。front/server 共通の判定 */
+export const hasAdminAuthority = (role: TeamRole): boolean => role === "master" || role === "admin"
 
 /**
  * チームの活動可否の管理方法。

--- a/my-app/app/api/web/team-schedules/join/route.test.ts
+++ b/my-app/app/api/web/team-schedules/join/route.test.ts
@@ -68,14 +68,14 @@ describe("POST /team-schedules/join", () => {
     expect(insert).not.toHaveBeenCalled()
   })
 
-  it("success: 招待トークンで individual として参加する（冪等INSERT）", async () => {
+  it("success: 招待トークンで member として参加する（冪等INSERT）", async () => {
     mockGetSessionUserId.mockResolvedValue("user-1")
     await redisSet(inviteKey(TOKEN), { teamId: TEAM.teamId }, 600)
     const res = await POST(createTestRequest(URL, { method: "POST", body: { token: TOKEN } }))
     const json = await res.json()
     expect(res.status).toBe(200)
     expect(json.team).toEqual(TEAM)
-    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ teamId: TEAM.teamId, userId: "user-1", teamRole: "individual" }))
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ teamId: TEAM.teamId, userId: "user-1", teamRole: "member" }))
     expect(onConflictDoNothing).toHaveBeenCalledTimes(1)
   })
 })

--- a/my-app/app/api/web/team-schedules/join/route.ts
+++ b/my-app/app/api/web/team-schedules/join/route.ts
@@ -14,7 +14,7 @@ import type { TeamSummary } from "@/app/_domains/teamSchedules/types"
  * body: { token }
  *
  * 招待は複数人で使うため使用後も削除しない（TTLで失効）。
- * 既に所属済みなら何もしない（冪等）。individual ロールで参加する。
+ * 既に所属済みなら何もしない（冪等）。member ロールで参加する。
  */
 export async function POST(req: NextRequest): Promise<NextResponse> {
   try {
@@ -52,8 +52,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ success: false, error: "参加先のチームが見つかりません" }, { status: 404 })
     }
 
-    // 既に所属していれば何もしない（冪等）。新規なら individual で参加
-    await db.insert(teamMembers).values({ teamId, userId, teamRole: "individual" }).onConflictDoNothing({
+    // 既に所属していれば何もしない（冪等）。新規なら member で参加
+    await db.insert(teamMembers).values({ teamId, userId, teamRole: "member" }).onConflictDoNothing({
       target: [teamMembers.teamId, teamMembers.userId],
     })
 

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.test.ts
@@ -57,9 +57,9 @@ describe("PUT /team-schedules/teams/[teamId]/team-status", () => {
     expect(insert).not.toHaveBeenCalled()
   })
 
-  it("failure: メンバーだが非adminは400（権限不足・書き込みもしない）", async () => {
+  it("failure: メンバーだがmember（admin相当未満）は400（権限不足・書き込みもしない）", async () => {
     mockGetSessionUserId.mockResolvedValue("user-1")
-    mockGetTeamRole.mockResolvedValue("individual")
+    mockGetTeamRole.mockResolvedValue("member")
     const req = createTestRequest(URL, { method: "PUT", body: { day: "2026-06-14", status: "ok", note: null } })
     const res = await PUT(req, ctxFor())
     expect(res.status).toBe(400)
@@ -103,6 +103,15 @@ describe("PUT /team-schedules/teams/[teamId]/team-status", () => {
     expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ teamId: TEAM_ID, day: "2026-06-14", status: "ok", note: "21:00~" }))
     expect(onConflictDoUpdate).toHaveBeenCalledTimes(1)
   })
+
+  it("success: masterならupsertされる（master ⊇ admin）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    mockGetTeamRole.mockResolvedValue("master")
+    const req = createTestRequest(URL, { method: "PUT", body: { day: "2026-06-14", status: "ok", note: null } })
+    const res = await PUT(req, ctxFor())
+    expect(res.status).toBe(200)
+    expect(insert).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe("DELETE /team-schedules/teams/[teamId]/team-status", () => {
@@ -123,9 +132,9 @@ describe("DELETE /team-schedules/teams/[teamId]/team-status", () => {
     expect(del).not.toHaveBeenCalled()
   })
 
-  it("failure: メンバーだが非adminは400（削除しない）", async () => {
+  it("failure: メンバーだがmember（admin相当未満）は400（削除しない）", async () => {
     mockGetSessionUserId.mockResolvedValue("user-1")
-    mockGetTeamRole.mockResolvedValue("individual")
+    mockGetTeamRole.mockResolvedValue("member")
     const req = createTestRequest(URL, { method: "DELETE", body: { day: "2026-06-14" } })
     const res = await DELETE(req, ctxFor())
     expect(res.status).toBe(400)

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teamDayStatus, teams } from "@/app/_domains/teamSchedules/_server/schema"
 import { getSessionUserId, getTeamRole } from "@/app/_domains/teamSchedules/_server/authz"
+import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
 import { isDayKey, isScheduleStatus, isUuid, isValidNote } from "@/app/_domains/teamSchedules/_server/validators"
 
 type RouteContext = { params: Promise<{ teamId: string }> }
@@ -14,7 +15,7 @@ type AuthzResult = { ok: true } | { ok: false; res: NextResponse }
  * team-status を編集できるかを「認証 → 認可 → モード確認」の順に判定する。
  * 入力検証より前に呼ぶこと（権限の無い相手の body は処理しない）。
  * - 非UUID / 非メンバー: 存在を隠して 404
- * - メンバーだが非admin: 権限不足で 400
+ * - メンバーだが admin 相当未満（member）: 権限不足で 400
  * - team モード以外のチーム: この機能の対象外で 400（members モードに孤児行を作らせない）
  */
 async function authorizeTeamStatusAdmin(req: NextRequest, teamId: string): Promise<AuthzResult> {
@@ -31,7 +32,7 @@ async function authorizeTeamStatusAdmin(req: NextRequest, teamId: string): Promi
   if (role === null) {
     return { ok: false, res: NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 }) }
   }
-  if (role !== "admin") {
+  if (!hasAdminAuthority(role)) {
     return { ok: false, res: NextResponse.json({ success: false, error: "チーム状態を編集する権限がありません" }, { status: 400 }) }
   }
 

--- a/my-app/app/api/web/team-schedules/teams/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/route.test.ts
@@ -77,7 +77,7 @@ describe("POST /team-schedules/teams", () => {
     expect(insert).not.toHaveBeenCalled()
   })
 
-  it("success: チームを作成し、作成者を admin で登録する（teams+team_members の2回INSERT）", async () => {
+  it("success: チームを作成し、作成者を master で登録する（teams+team_members の2回INSERT）", async () => {
     mockGetSessionUserId.mockResolvedValue("user-1")
     mockCanCreateTeam.mockResolvedValue(true)
     const res = await POST(createTestRequest(URL, { method: "POST", body: validBody }))
@@ -86,7 +86,7 @@ describe("POST /team-schedules/teams", () => {
     expect(json.team).toEqual(TEAM)
     // teams INSERT → team_members INSERT の2回
     expect(insert).toHaveBeenCalledTimes(2)
-    // 作成者が admin として登録される
-    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ teamId: TEAM.teamId, userId: "user-1", teamRole: "admin" }))
+    // 作成者が master として登録される
+    expect(insertValues).toHaveBeenCalledWith(expect.objectContaining({ teamId: TEAM.teamId, userId: "user-1", teamRole: "master" }))
   })
 })

--- a/my-app/app/api/web/team-schedules/teams/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/route.ts
@@ -32,7 +32,7 @@ export async function GET(): Promise<NextResponse> {
 /**
  * POST /api/web/team-schedules/teams
  * チームを新規作成する（要ログイン + 作成権限）。
- * 作成者をそのチームの admin メンバーとして登録する。
+ * 作成者をそのチームの master メンバーとして登録する（チームに必ず1人の master）。
  * body: { name, description, managementMode, requiredCount }
  */
 export async function POST(req: NextRequest): Promise<NextResponse> {
@@ -63,9 +63,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const managementMode = body.managementMode
     const requiredCount = body.requiredCount
 
-    // チーム作成 → 作成者を admin メンバーに登録。
+    // チーム作成 → 作成者を master メンバーに登録。
     // neon-http はトランザクション非対応のため逐次 INSERT（auth/verify と同じ流儀）。
-    // 既知のリスク: teams INSERT 成功後に team_members INSERT が失敗すると、admin 不在の
+    // 既知のリスク: teams INSERT 成功後に team_members INSERT が失敗すると、master 不在の
     // チームが public 一覧に残る（誰も編集・招待できない孤児）。重要度は高いがエッジ。
     // 恒久対応は別 Issue で検討（neon-serverless へ移行してトランザクション化 等）。
     const inserted = await db
@@ -79,7 +79,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         managementMode: teams.managementMode,
       })
     const team = inserted[0]
-    await db.insert(teamMembers).values({ teamId: team.teamId, userId, teamRole: "admin" })
+    await db.insert(teamMembers).values({ teamId: team.teamId, userId, teamRole: "master" })
 
     const result: TeamSummary = team
     return NextResponse.json({ success: true, team: result })

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation"
 import LolHeader from "@/app/lol/_components/LolHeader"
 import { useOverlay } from "@/app/_client/lib/modal/ModalContext"
 import type { ScheduleEntry, ScheduleStatus, SessionUser, TeamSchedule, TeamSummary } from "@/app/_domains/teamSchedules/types"
+import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
 import {
   createInvite,
   deleteSchedule,
@@ -313,11 +314,11 @@ export function TeamSchedulesPage() {
     )
   }, [open, close, reloadTeams])
 
-  // 選択中の自チームで、ログインユーザーが admin か
+  // 選択中の自チームで、ログインユーザーが admin 相当以上（master/admin）か
   const isOwnAdmin = useMemo(() => {
     if (!session || !ownTeamId) return false
     const ownTeam = schedulesByTeam[ownTeamId]
-    return !!ownTeam?.members.some((m) => m.userId === session.userId && m.teamRole === "admin")
+    return !!ownTeam?.members.some((m) => m.userId === session.userId && hasAdminAuthority(m.teamRole))
   }, [session, ownTeamId, schedulesByTeam])
 
   // 招待リンクを発行して表示する
@@ -340,8 +341,8 @@ export function TeamSchedulesPage() {
     const ownIndexed = indexSchedules(ownTeam.schedules)
     const oppIndexed = new Map(opponents.map((t) => [t.teamId, indexSchedules(t.schedules)]))
 
-    // ログインユーザーがそのチームの admin か
-    const isAdminOf = (team: TeamSchedule): boolean => !!session && team.members.some((m) => m.userId === session.userId && m.teamRole === "admin")
+    // ログインユーザーがそのチームの admin 相当以上（master/admin）か
+    const isAdminOf = (team: TeamSchedule): boolean => !!session && team.members.some((m) => m.userId === session.userId && hasAdminAuthority(m.teamRole))
 
     // チーム単位モードのチームを1列にまとめる（own/opponent 共通）
     const buildTeamColumn = (team: TeamSchedule, idPrefix: string): ScheduleColumn => {

--- a/my-app/drizzle/0002_marvelous_grandmaster.sql
+++ b/my-app/drizzle/0002_marvelous_grandmaster.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "team_members" DROP CONSTRAINT "team_members_team_role_chk";--> statement-breakpoint
+ALTER TABLE "team_members" ALTER COLUMN "team_role" SET DEFAULT 'member';--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_team_members_one_master" ON "team_members" USING btree ("team_id") WHERE "team_members"."team_role" = 'master';--> statement-breakpoint
+ALTER TABLE "team_members" ADD CONSTRAINT "team_members_team_role_chk" CHECK ("team_members"."team_role" in ('master', 'admin', 'member'));

--- a/my-app/drizzle/meta/0002_snapshot.json
+++ b/my-app/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,501 @@
+{
+  "id": "406672de-c7a5-421c-84fd-79621136c5da",
+  "prevId": "ce5b991a-7fbb-4bbd-ae3a-b81c8c086482",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.discord_links": {
+      "name": "discord_links",
+      "schema": "",
+      "columns": {
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_links_user": {
+          "name": "idx_discord_links_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_links_user_id_users_user_id_fk": {
+          "name": "discord_links_user_id_users_user_id_fk",
+          "tableFrom": "discord_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_schedules_team_day": {
+          "name": "idx_schedules_team_day",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_team_member_fk": {
+          "name": "schedules_team_member_fk",
+          "tableFrom": "schedules",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "team_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "schedules_team_id_user_id_day_pk": {
+          "name": "schedules_team_id_user_id_day_pk",
+          "columns": [
+            "team_id",
+            "user_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schedules_status_chk": {
+          "name": "schedules_status_chk",
+          "value": "\"schedules\".\"status\" in ('ok', 'maybe', 'ng')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_day_status": {
+      "name": "team_day_status",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_day_status_team_id_teams_team_id_fk": {
+          "name": "team_day_status_team_id_teams_team_id_fk",
+          "tableFrom": "team_day_status",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_day_status_team_id_day_pk": {
+          "name": "team_day_status_team_id_day_pk",
+          "columns": [
+            "team_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_day_status_status_chk": {
+          "name": "team_day_status_status_chk",
+          "value": "\"team_day_status\".\"status\" in ('ok', 'maybe', 'ng')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "top": {
+          "name": "top",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "jungle": {
+          "name": "jungle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mid": {
+          "name": "mid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "adc": {
+          "name": "adc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "support": {
+          "name": "support",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_team_members_one_master": {
+          "name": "uq_team_members_one_master",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_members\".\"team_role\" = 'master'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_members_user": {
+          "name": "idx_team_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_team_id_fk": {
+          "name": "team_members_team_id_teams_team_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_user_id_fk": {
+          "name": "team_members_user_id_users_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_team_id_user_id_pk": {
+          "name": "team_members_team_id_user_id_pk",
+          "columns": [
+            "team_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_members_team_role_chk": {
+          "name": "team_members_team_role_chk",
+          "value": "\"team_members\".\"team_role\" in ('master', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_count": {
+          "name": "required_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "management_mode": {
+          "name": "management_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "teams_required_count_chk": {
+          "name": "teams_required_count_chk",
+          "value": "\"teams\".\"required_count\" >= 1"
+        },
+        "teams_management_mode_chk": {
+          "name": "teams_management_mode_chk",
+          "value": "\"teams\".\"management_mode\" in ('members', 'team')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/my-app/drizzle/meta/_journal.json
+++ b/my-app/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781418541491,
       "tag": "0001_numerous_hulk",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781479697901,
+      "tag": "0002_marvelous_grandmaster",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

closes #98

チームの権限ロールを `individual` / `admin` の2値から **`master` / `admin` / `member`** の3値に変更。`individual` は意味的に `member` と同一のため rename。権限は **master ⊇ admin ⊇ member** の包含関係。

本番 Neon にチームデータが無いことを確認済みのため、データ移行は不要（スキーマ差し替えのみ）。

## 変更点

- **schema**: `team_role` enum/default(`member`)/CHECK を3値化。`master` はチームに高々1人を担保する部分ユニークインデックス `uq_team_members_one_master` を追加
- **types**: front/server 共通の `hasAdminAuthority(master|admin)` を新設し、ベタ書きの `=== "admin"` を一掃
- **authz**: `assertTeamAdmin` を「admin相当以上（master含む）」に修正、`assertTeamMaster` を追加
- **teams**: チーム作成者を `master` で登録（必ず1人の master を成立）／ **join**: 招待参加は `member`
- **frontend**: admin 判定2箇所を `hasAdminAuthority` に
- **migration**: `0002_marvelous_grandmaster.sql` を生成

## 確認

- `npx tsc --noEmit` / `npm run lint` クリーン
- team-schedules テスト 39件パス（master が team-status を編集できるケースを追加）

## 範囲外（別 issue 想定）

issue 記載の「master 権限の譲渡」「admin による member 管理」等のロール変更エンドポイント／UI は本PRの範囲外。今回は3ロール＋階層ゲーティングの土台まで。`master` 下限1人は「作成者=master」で成立するが、退会・降格で master 不在になる経路は譲渡機能実装時にアプリ側で塞ぐ必要あり（DBは上限のみ担保）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)