### PR TITLE
fix: mainの全テストで失敗していたチームスケジュール系テストを修正

### DIFF
--- a/my-app/app/api/web/team-schedules/auth/verify/route.test.ts
+++ b/my-app/app/api/web/team-schedules/auth/verify/route.test.ts
@@ -7,7 +7,9 @@ import { magicLinkKey } from "@/app/_domains/teamSchedules/_server/redisKeys"
 // DB: 既存リンク無し → users + discord_links を作成するパスを再現
 const selectLimit = vi.fn()
 const selectWhere = vi.fn(() => ({ limit: selectLimit }))
-const selectFrom = vi.fn(() => ({ where: selectWhere }))
+// userResolver は discord_links と users を innerJoin して1クエリで解決する
+const selectInnerJoin = vi.fn(() => ({ where: selectWhere }))
+const selectFrom = vi.fn(() => ({ innerJoin: selectInnerJoin }))
 const select = vi.fn((..._a: unknown[]) => ({ from: selectFrom }))
 const insertReturning = vi.fn(async () => [{ userId: "new-user-id", displayName: "テスト太郎" }])
 const insertValues = vi.fn(() => ({ returning: insertReturning, then: (r: (v: undefined) => void) => r(undefined) }))

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.test.ts
@@ -55,6 +55,7 @@ describe("POST /team-schedules/teams/[teamId]/invite", () => {
     expect(redisSet).toHaveBeenCalledTimes(1)
     const [key, payload] = (redisSet as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]
     expect(key).toMatch(/^ts:invite:/)
-    expect(payload).toEqual({ teamId: TEAM_ID })
+    // 発行者（userId）も invitedBy として記録される（#108）
+    expect(payload).toEqual({ teamId: TEAM_ID, invitedBy: "user-1" })
   })
 })


### PR DESCRIPTION
## 概要

`develop→main` マージ後の main への push で走る全テスト（`npx vitest run`）が3件失敗していたため修正する hotfix。

## なぜ PR では検知できなかったか

CI はイベント種別でテスト範囲を変えている:

- **PR時**: `npx vitest run --changed`（変更差分に関連するテストのみ）
- **mainへのpush時**: `npx vitest run`（全テスト）

そのため `feat→develop` / `develop→main` の各PRでは取りこぼし、main マージで初めて露見した。

## 修正内容

- **auth/verify**: `userResolver` の innerJoin 化（d0898ae）に合わせ、`db` モックのチェーンに `innerJoin` を追加（`innerJoin is not a function` → 500 を解消）
- **invite**: 招待トークンに `invitedBy` を記録する変更（#108）に合わせ、期待ペイロードを `{ teamId, invitedBy }` に更新

いずれもテスト側の追従修正で、プロダクションコードの挙動は変更なし。

## 確認

- `npx vitest run` 全137テスト green

🤖 Generated with [Claude Code](https://claude.com/claude-code)