### PR TITLE
perf: チームスケジュール読み取り3ルートにServer-Timing計装を追加 (Refs #111)

### DIFF
--- a/my-app/app/_server/lib/serverTiming.ts
+++ b/my-app/app/_server/lib/serverTiming.ts
@@ -1,0 +1,42 @@
+/**
+ * Server-Timing 計測ヘルパー
+ *
+ * 「推測せず計測」用。各 DB クエリ / Redis アクセスの所要時間を区間計測し、
+ * `Server-Timing` レスポンスヘッダーに載せる。ブラウザの DevTools → Network →
+ * 各リクエストの「Timing」タブに内訳が表示される。
+ *
+ * 使い方:
+ *   const t = new ServerTiming()
+ *   const rows = await t.measure("db_users", () => db.select()...)
+ *   const res = NextResponse.json({ ... })
+ *   t.applyTo(res)            // ヘッダーを付与
+ *
+ * total（このオブジェクト生成からの経過）も自動で載るため、
+ * 「total −（各区間の総和）」でコールドスタート/接続オーバーヘッドを概算できる。
+ */
+export class ServerTiming {
+  private readonly startedAt = Date.now()
+  private readonly marks: { name: string; dur: number }[] = []
+
+  /** 非同期処理を区間計測する（失敗時も計測する） */
+  async measure<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    const start = Date.now()
+    try {
+      return await fn()
+    } finally {
+      this.marks.push({ name, dur: Date.now() - start })
+    }
+  }
+
+  /** Server-Timing ヘッダー値を組み立てる */
+  headerValue(): string {
+    const entries = this.marks.map((m) => `${m.name};dur=${m.dur}`)
+    entries.push(`total;dur=${Date.now() - this.startedAt}`)
+    return entries.join(", ")
+  }
+
+  /** レスポンスにヘッダーを付与する */
+  applyTo(res: { headers: Headers }): void {
+    res.headers.set("Server-Timing", this.headerValue())
+  }
+}

--- a/my-app/app/api/web/team-schedules/session/route.ts
+++ b/my-app/app/api/web/team-schedules/session/route.ts
@@ -3,26 +3,34 @@ import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { users } from "@/app/_domains/teamSchedules/_server/schema"
 import { canCreateTeam, getSessionUserId } from "@/app/_domains/teamSchedules/_server/authz"
+import { ServerTiming } from "@/app/_server/lib/serverTiming"
 
 /**
  * GET /api/web/team-schedules/session
  * ログイン中ユーザーを返す。未ログインは 401（クライアントは null として扱う）。
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
+  const t = new ServerTiming()
   try {
-    const userId = await getSessionUserId(req)
+    const userId = await t.measure("session_redis", () => getSessionUserId(req))
     if (!userId) {
-      return NextResponse.json({ success: false, error: "未ログイン" }, { status: 401 })
+      const res = NextResponse.json({ success: false, error: "未ログイン" }, { status: 401 })
+      t.applyTo(res)
+      return res
     }
 
-    const rows = await db.select({ displayName: users.displayName }).from(users).where(eq(users.userId, userId)).limit(1)
+    const rows = await t.measure("db_users", () => db.select({ displayName: users.displayName }).from(users).where(eq(users.userId, userId)).limit(1))
     if (!rows[0]) {
       // セッションは有効だがユーザーが消えている（退会等）→ 未ログイン扱い
-      return NextResponse.json({ success: false, error: "未ログイン" }, { status: 401 })
+      const res = NextResponse.json({ success: false, error: "未ログイン" }, { status: 401 })
+      t.applyTo(res)
+      return res
     }
 
-    const allowed = await canCreateTeam(userId)
-    return NextResponse.json({ success: true, user: { userId, displayName: rows[0].displayName, canCreateTeam: allowed } })
+    const allowed = await t.measure("db_can_create", () => canCreateTeam(userId))
+    const res = NextResponse.json({ success: true, user: { userId, displayName: rows[0].displayName, canCreateTeam: allowed } })
+    t.applyTo(res)
+    return res
   } catch (error) {
     console.error("team-schedules session error:", error)
     return NextResponse.json({ success: false, error: "セッション取得に失敗しました" }, { status: 500 })

--- a/my-app/app/api/web/team-schedules/session/route.ts
+++ b/my-app/app/api/web/team-schedules/session/route.ts
@@ -33,6 +33,9 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     return res
   } catch (error) {
     console.error("team-schedules session error:", error)
-    return NextResponse.json({ success: false, error: "セッション取得に失敗しました" }, { status: 500 })
+    // どのクエリで・何ms後に落ちたかを計測するため 500 経路にもヘッダーを付ける
+    const res = NextResponse.json({ success: false, error: "セッション取得に失敗しました" }, { status: 500 })
+    t.applyTo(res)
+    return res
   }
 }

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
@@ -5,6 +5,7 @@ import { schedules, teamDayStatus, teamMembers, teams, users } from "@/app/_doma
 import { getSessionUserId, assertTeamMember } from "@/app/_domains/teamSchedules/_server/authz"
 import { isDayKey, isScheduleStatus, isUuid, isValidNote } from "@/app/_domains/teamSchedules/_server/validators"
 import type { LolRoleFlags, ScheduleEntry, TeamDayStatusEntry, TeamSchedule, TeamScheduleMember } from "@/app/_domains/teamSchedules/types"
+import { ServerTiming } from "@/app/_server/lib/serverTiming"
 
 type RouteContext = { params: Promise<{ teamId: string }> }
 
@@ -13,6 +14,7 @@ type RouteContext = { params: Promise<{ teamId: string }> }
  * 期間内の schedules + members（グリッド描画用・public read）。
  */
 export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  const t = new ServerTiming()
   try {
     const { teamId } = await ctx.params
     if (!isUuid(teamId)) {
@@ -26,48 +28,58 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
       return NextResponse.json({ success: false, error: "期間の指定が不正です" }, { status: 400 })
     }
 
-    const teamRows = await db
-      .select({ teamId: teams.teamId, name: teams.name, description: teams.description, requiredCount: teams.requiredCount, managementMode: teams.managementMode })
-      .from(teams)
-      .where(eq(teams.teamId, teamId))
-      .limit(1)
+    const teamRows = await t.measure("db_team", () =>
+      db
+        .select({ teamId: teams.teamId, name: teams.name, description: teams.description, requiredCount: teams.requiredCount, managementMode: teams.managementMode })
+        .from(teams)
+        .where(eq(teams.teamId, teamId))
+        .limit(1),
+    )
     const team = teamRows[0]
     if (!team) {
-      return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+      const res = NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+      t.applyTo(res)
+      return res
     }
 
-    const memberRows = await db
-      .select({
-        userId: teamMembers.userId,
-        displayName: users.displayName,
-        teamRole: teamMembers.teamRole,
-        top: teamMembers.top,
-        jungle: teamMembers.jungle,
-        mid: teamMembers.mid,
-        adc: teamMembers.adc,
-        support: teamMembers.support,
-      })
-      .from(teamMembers)
-      .innerJoin(users, eq(users.userId, teamMembers.userId))
-      .where(eq(teamMembers.teamId, teamId))
+    const memberRows = await t.measure("db_members", () =>
+      db
+        .select({
+          userId: teamMembers.userId,
+          displayName: users.displayName,
+          teamRole: teamMembers.teamRole,
+          top: teamMembers.top,
+          jungle: teamMembers.jungle,
+          mid: teamMembers.mid,
+          adc: teamMembers.adc,
+          support: teamMembers.support,
+        })
+        .from(teamMembers)
+        .innerJoin(users, eq(users.userId, teamMembers.userId))
+        .where(eq(teamMembers.teamId, teamId)),
+    )
 
     const members: TeamScheduleMember[] = memberRows.map((m) => {
       const roles: LolRoleFlags = { top: m.top, jungle: m.jungle, mid: m.mid, adc: m.adc, support: m.support }
       return { userId: m.userId, displayName: m.displayName, teamRole: m.teamRole, roles }
     })
 
-    const scheduleRows = await db
-      .select({ userId: schedules.userId, day: schedules.day, status: schedules.status, note: schedules.note })
-      .from(schedules)
-      .where(and(eq(schedules.teamId, teamId), between(schedules.day, from, to)))
+    const scheduleRows = await t.measure("db_schedules", () =>
+      db
+        .select({ userId: schedules.userId, day: schedules.day, status: schedules.status, note: schedules.note })
+        .from(schedules)
+        .where(and(eq(schedules.teamId, teamId), between(schedules.day, from, to))),
+    )
 
     const scheduleEntries: ScheduleEntry[] = scheduleRows.map((s) => ({ userId: s.userId, day: s.day, status: s.status, note: s.note }))
 
     // チーム単位モードの日別状態（members モードでは行が無いので空になる）
-    const teamStatusRows = await db
-      .select({ day: teamDayStatus.day, status: teamDayStatus.status, note: teamDayStatus.note })
-      .from(teamDayStatus)
-      .where(and(eq(teamDayStatus.teamId, teamId), between(teamDayStatus.day, from, to)))
+    const teamStatusRows = await t.measure("db_team_status", () =>
+      db
+        .select({ day: teamDayStatus.day, status: teamDayStatus.status, note: teamDayStatus.note })
+        .from(teamDayStatus)
+        .where(and(eq(teamDayStatus.teamId, teamId), between(teamDayStatus.day, from, to))),
+    )
     const teamStatusEntries: TeamDayStatusEntry[] = teamStatusRows.map((s) => ({ day: s.day, status: s.status, note: s.note }))
 
     const result: TeamSchedule = {
@@ -80,7 +92,9 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
       schedules: scheduleEntries,
       teamStatus: teamStatusEntries,
     }
-    return NextResponse.json({ success: true, team: result })
+    const res = NextResponse.json({ success: true, team: result })
+    t.applyTo(res)
+    return res
   } catch (error) {
     console.error("team-schedules schedule GET error:", error)
     return NextResponse.json({ success: false, error: "予定の取得に失敗しました" }, { status: 500 })

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
@@ -97,7 +97,10 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
     return res
   } catch (error) {
     console.error("team-schedules schedule GET error:", error)
-    return NextResponse.json({ success: false, error: "予定の取得に失敗しました" }, { status: 500 })
+    // どのクエリで・何ms後に落ちたかを計測するため 500 経路にもヘッダーを付ける
+    const res = NextResponse.json({ success: false, error: "予定の取得に失敗しました" }, { status: 500 })
+    t.applyTo(res)
+    return res
   }
 }
 

--- a/my-app/app/api/web/team-schedules/teams/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/route.ts
@@ -31,7 +31,10 @@ export async function GET(): Promise<NextResponse> {
     return res
   } catch (error) {
     console.error("team-schedules teams GET error:", error)
-    return NextResponse.json({ success: false, error: "チーム一覧の取得に失敗しました" }, { status: 500 })
+    // どのクエリで・何ms後に落ちたかを計測するため 500 経路にもヘッダーを付ける
+    const res = NextResponse.json({ success: false, error: "チーム一覧の取得に失敗しました" }, { status: 500 })
+    t.applyTo(res)
+    return res
   }
 }
 

--- a/my-app/app/api/web/team-schedules/teams/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/route.ts
@@ -4,25 +4,31 @@ import { teamMembers, teams } from "@/app/_domains/teamSchedules/_server/schema"
 import { canCreateTeam, getSessionUserId } from "@/app/_domains/teamSchedules/_server/authz"
 import { isManagementMode, isValidRequiredCount, isValidTeamDescription, isValidTeamName } from "@/app/_domains/teamSchedules/_server/validators"
 import type { TeamSummary } from "@/app/_domains/teamSchedules/types"
+import { ServerTiming } from "@/app/_server/lib/serverTiming"
 
 /**
  * GET /api/web/team-schedules/teams
  * チーム一覧（比較セレクタ用・public read）。
  */
 export async function GET(): Promise<NextResponse> {
+  const t = new ServerTiming()
   try {
-    const rows = await db
-      .select({
-        teamId: teams.teamId,
-        name: teams.name,
-        description: teams.description,
-        requiredCount: teams.requiredCount,
-        managementMode: teams.managementMode,
-      })
-      .from(teams)
+    const rows = await t.measure("db_teams", () =>
+      db
+        .select({
+          teamId: teams.teamId,
+          name: teams.name,
+          description: teams.description,
+          requiredCount: teams.requiredCount,
+          managementMode: teams.managementMode,
+        })
+        .from(teams),
+    )
 
     const list: TeamSummary[] = rows
-    return NextResponse.json({ success: true, teams: list })
+    const res = NextResponse.json({ success: true, teams: list })
+    t.applyTo(res)
+    return res
   } catch (error) {
     console.error("team-schedules teams GET error:", error)
     return NextResponse.json({ success: false, error: "チーム一覧の取得に失敗しました" }, { status: 500 })


### PR DESCRIPTION
## 概要

#111「チームスケジュール：ロードが遅い」の **原因特定（計測）** を目的とした計装PR。
「推測せず計測せよ」の方針に従い、**性能改善そのものは行わず**、まずボトルネックを実データで特定するための `Server-Timing` ヘッダーを追加する。挙動は一切変えない。

## 変更内容

- `app/_server/lib/serverTiming.ts` を新規追加
  - `measure(name, fn)` で非同期処理を区間計測（失敗時も `finally` で計測）
  - `applyTo(res)` で `Server-Timing` レスポンスヘッダーを付与
  - `total`（オブジェクト生成からの経過）も自動付与 → `total −（区間総和）` でコールドスタート/接続オーバーヘッドを概算
- 読み取り3ルートに計装を追加
  - `session`: `session_redis` / `db_users` / `db_can_create`
  - `teams` (GET): `db_teams`
  - `schedule` (GET): `db_team` / `db_members` / `db_schedules` / `db_team_status`
- 各ルートの **500（catch）経路にもヘッダーを付与** — クエリ失敗時に「どのクエリで・何ms後に落ちたか」を計測できるようにする

## 計測手順

1. このブランチを Vercel プレビューにデプロイ
2. `/team_schedules` を開いて操作
3. DevTools → Network → 対象リクエスト（session / teams / schedule）を選択 → **Timing** タブで内訳を確認
4. cold-start（初回）と warm（2回目以降）を比較

## 計測後の改善候補（本PRには含めない）

- schedule の4クエリ並列化
- session の2クエリ並列化
- `ownTeamId` の localStorage 永続化（チーム選択待ちの解消）
- Redis セッションのステートレス化（TCP コールドスタート回避）

🤖 Generated with [Claude Code](https://claude.com/claude-code)