### PR TITLE
fix: team-schedule-invite をdefer化してコールドスタートのタイムアウトを解消

### DIFF
--- a/my-app/app/_server/lib/discord/api.ts
+++ b/my-app/app/_server/lib/discord/api.ts
@@ -2,7 +2,7 @@
  * Discord REST API 通信用のヘルパー関数
  */
 
-import { APIActionRowComponent, APIComponentInMessageActionRow } from "discord-api-types/v10"
+import { APIActionRowComponent, APIComponentInMessageActionRow, MessageFlags } from "discord-api-types/v10"
 import { DISCORD_API_BASE_URL, DISCORD_BOT_TOKEN } from "@/app/_server/lib/env"
 
 export interface DiscordMessageResponse {
@@ -314,6 +314,47 @@ export async function editWebhookOriginalMessage(applicationId: string, token: s
 
   const response = await fetch(url, {
     method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new DiscordApiError(response.status, response.statusText, errorData)
+  }
+}
+
+/**
+ * Webhookを通じてインタラクションの followup メッセージを送信する。
+ * 元の応答が ephemeral でも、ここで ephemeral=false にすれば public なメッセージを投稿できる。
+ * （初回が ephemeral deferred のスラッシュコマンドから、public な募集メッセージを出す用途）
+ * @param applicationId - アプリケーションID
+ * @param token - インタラクショントークン
+ * @param content - メッセージ本文
+ * @param components - コンポーネント配列
+ * @param ephemeral - true で本人にのみ表示（既定: false = public）
+ */
+export async function createFollowupMessage(
+  applicationId: string,
+  token: string,
+  content: string,
+  components?: APIActionRowComponent<APIComponentInMessageActionRow>[],
+  ephemeral = false,
+): Promise<void> {
+  const url = `${DISCORD_API_BASE_URL}/webhooks/${applicationId}/${token}`
+
+  const body: DiscordMessageBody & { flags?: number } = { content }
+  if (components && components.length > 0) {
+    body.components = components
+  }
+  if (ephemeral) {
+    body.flags = MessageFlags.Ephemeral
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
     headers: {
       "Content-Type": "application/json",
     },

--- a/my-app/app/_server/lib/discord/api.ts
+++ b/my-app/app/_server/lib/discord/api.ts
@@ -345,7 +345,7 @@ export async function createFollowupMessage(
 ): Promise<void> {
   const url = `${DISCORD_API_BASE_URL}/webhooks/${applicationId}/${token}`
 
-  const body: DiscordMessageBody & { flags?: number } = { content }
+  const body: DiscordMessageBody & { flags?: MessageFlags } = { content }
   if (components && components.length > 0) {
     body.components = components
   }

--- a/my-app/app/api/discord/command/team-schedule/invite.ts
+++ b/my-app/app/api/discord/command/team-schedule/invite.ts
@@ -18,7 +18,7 @@ import { createInviteToken, type InvitePayload } from "@/app/_domains/teamSchedu
 import { resolveOrCreateUserByDiscordId } from "@/app/_domains/teamSchedules/_server/userResolver"
 import { inviteKey } from "@/app/_domains/teamSchedules/_server/redisKeys"
 import { redisGet } from "@/app/_server/lib/redis/redis"
-import { editWebhookOriginalMessage } from "@/app/_server/lib/discord/api"
+import { editWebhookOriginalMessage, createFollowupMessage } from "@/app/_server/lib/discord/api"
 import { CLIENT_ACTIONS } from "@/app/_server/util/commands"
 import { extractInviteToken } from "@/app/api/discord/util/extractCustomIdParam"
 
@@ -37,14 +37,6 @@ function extractUser(user: APIUser | undefined): { discordUserId?: string; usern
     discordUserId: user?.id,
     username: user?.global_name ?? user?.username ?? "Discordユーザー",
   }
-}
-
-/** ephemeral テキスト返信のショートハンド（本人にだけ表示・即時応答用） */
-function ephemeral(content: string): NextResponse {
-  return NextResponse.json({
-    type: InteractionResponseType.ChannelMessageWithSource,
-    data: { content, flags: MessageFlags.Ephemeral },
-  })
 }
 
 /** ephemeral の deferred 応答（「考え中…」）。重い処理を after に逃がす際の即時 ACK */
@@ -143,53 +135,64 @@ async function joinAsMember(teamId: string, userId: string, invitedBy?: string):
   })
 }
 
-/**
- * `/team-schedule-invite` コマンド。
- * 実行者が master/admin のチームへの参加募集ボタンを投稿する。
- * - 管理チームが1つ: 公開メッセージを即投稿
- * - 複数: ephemeral のセレクトメニューで選ばせる
- */
-export async function teamScheduleInviteCommand(interaction: APIChatInputApplicationCommandInteraction): Promise<NextResponse> {
-  const { discordUserId } = extractUser(interaction.member?.user ?? interaction.user)
-  if (!discordUserId) {
-    return ephemeral("ユーザー情報を取得できませんでした。再度お試しください。")
-  }
-
-  // 未登録（リンク無し）も管理チーム0件も、1クエリで同じ空配列として扱う
-  const { userId, teams: managed } = await findManagedTeamsByDiscordId(discordUserId)
-  if (managed.length === 0) {
-    return ephemeral("あなたが管理しているチームがありません。")
-  }
-
-  if (managed.length === 1) {
-    const recruit = await buildRecruitContent(managed[0], userId)
-    return NextResponse.json({
-      type: InteractionResponseType.ChannelMessageWithSource,
-      data: { content: recruit.content, components: recruit.components },
-    })
-  }
-
-  // 複数チームの管理者: セレクトメニューで選ばせる（StringSelect は最大25件）
-  return NextResponse.json({
-    type: InteractionResponseType.ChannelMessageWithSource,
-    data: {
-      content: "募集ボタンを出すチームを選んでください。",
-      flags: MessageFlags.Ephemeral,
+/** 複数チーム管理者向けのセレクトメニュー ActionRow（StringSelect は最大25件） */
+function selectTeamRow(managed: TeamRef[]): APIActionRowComponent<APIComponentInMessageActionRow>[] {
+  return [
+    {
+      type: ComponentType.ActionRow,
       components: [
         {
-          type: ComponentType.ActionRow,
-          components: [
-            {
-              type: ComponentType.StringSelect,
-              custom_id: CLIENT_ACTIONS.TEAM_SCHEDULE.SELECT_INVITE_TEAM,
-              placeholder: "チームを選択",
-              options: managed.slice(0, 25).map((t) => ({ label: t.name, value: t.teamId })),
-            },
-          ],
+          type: ComponentType.StringSelect,
+          custom_id: CLIENT_ACTIONS.TEAM_SCHEDULE.SELECT_INVITE_TEAM,
+          placeholder: "チームを選択",
+          options: managed.slice(0, 25).map((t) => ({ label: t.name, value: t.teamId })),
         },
       ],
     },
+  ]
+}
+
+/**
+ * `/team-schedule-invite` コマンド。
+ * 実行者が master/admin のチームへの参加募集ボタンを投稿する。
+ * - 管理チームが1つ: 公開メッセージを投稿
+ * - 複数: ephemeral のセレクトメニューで選ばせる
+ *
+ * cold start（Vercel/Neon）で DB 往復が3秒制限を超え得るため即 ephemeral deferred で ACK し、
+ * 実処理は after に逃がす。1チームの公開募集メッセージだけは public followup として投稿する。
+ */
+export function teamScheduleInviteCommand(interaction: APIChatInputApplicationCommandInteraction): NextResponse {
+  const { token: interactionToken, application_id } = interaction
+
+  after(async () => {
+    try {
+      const { discordUserId } = extractUser(interaction.member?.user ?? interaction.user)
+      if (!discordUserId) {
+        return safeEdit(application_id, interactionToken, "ユーザー情報を取得できませんでした。再度お試しください。")
+      }
+
+      // 未登録（リンク無し）も管理チーム0件も、1クエリで同じ空配列として扱う
+      const { userId, teams: managed } = await findManagedTeamsByDiscordId(discordUserId)
+      if (managed.length === 0) {
+        return safeEdit(application_id, interactionToken, "あなたが管理しているチームがありません。")
+      }
+
+      // 1チーム: ephemeral の元応答は確認文に差し替え、募集メッセージは public followup で投稿
+      if (managed.length === 1) {
+        const recruit = await buildRecruitContent(managed[0], userId)
+        await createFollowupMessage(application_id, interactionToken, recruit.content, recruit.components)
+        return safeEdit(application_id, interactionToken, `「${managed[0].name}」の募集メッセージを投稿しました。`)
+      }
+
+      // 複数チームの管理者: ephemeral のセレクトメニューで選ばせる
+      return safeEdit(application_id, interactionToken, "募集ボタンを出すチームを選んでください。", selectTeamRow(managed))
+    } catch (e) {
+      console.error("teamScheduleInviteCommand after error:", e)
+      return safeEdit(application_id, interactionToken, "募集ボタンの発行に失敗しました。しばらく待ってから再度お試しください。")
+    }
   })
+
+  return deferredEphemeral()
 }
 
 /**


### PR DESCRIPTION
## 背景・問題

`/team-schedule-invite` がコールドスタート時の初回実行でタイムアウトする報告。
ログには 200 OK しか残らないのに Discord 上は応答なし、という症状。

原因は **スラッシュコマンド本体だけが defer しておらず、DBクエリを同期的に待ってから応答していた** こと。ボタン/セレクトのハンドラーは既に defer + `after` 済みだったが、コマンド本体は未対応だった。Vercel/Neon のコールドスタートが重なると、この1往復が Discord の3秒制限を超えてタイムアウトしていた（サーバー側は処理完走するためログには 200 だけ残る）。

## 変更内容

- `teamScheduleInviteCommand` を **ephemeral deferred で即ACK → 実処理を `after` に移動**（他ハンドラーと同じ流儀に統一）
- ephemeral で defer した元メッセージは編集で public 化できないため、**1チーム時の公開募集メッセージだけ public followup として新規投稿**し、元の ephemeral は「投稿しました」確認文に差し替え
- 0件・複数（セレクト）ケースは ephemeral のまま編集
- followup 送信用に `createFollowupMessage` を `api.ts` に追加

## 挙動の変化（要確認）

- 1チーム管理時: 以前は募集メッセージを直接 public 投稿していたが、今後は実行者向けの ephemeral 確認（「投稿しました」）+ public な募集メッセージの2メッセージ構成になる。
- 0件・複数ケースのエラー/セレクト表示も deferred 経由になり、ごく一瞬「考え中…」を挟む。

## 確認

- `npm run lint` / `npx tsc --noEmit` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)