### PR TITLE
fix: チーム招待参加失敗の再発防止（main/develop 自動マイグレーション）+ custom_idログノイズ抑制

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,55 @@
+name: DB Migrate (Neon)
+
+# drizzle/ 配下が変わった状態で main にマージされたら、本番 Neon に migrate を自動適用する。
+# 手動実行(workflow_dispatch)も可能。
+# 注: 列追加など加算的なマイグレーション前提。破壊的変更は手動運用で慎重に。
+on:
+  push:
+    branches: [main]
+    paths:
+      - "my-app/drizzle/**"
+      - ".github/workflows/db-migrate.yml"
+  workflow_dispatch:
+
+# 同時に複数のマイグレーションが走らないよう直列化する
+concurrency:
+  group: db-migrate-production
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate required secrets
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "Error: DATABASE_URL secret is not set"
+            exit 1
+          fi
+          echo "DATABASE_URL is configured"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: my-app/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ./my-app
+        run: npm ci
+
+      # 注: Secret の DATABASE_URL は pooled(-pooler) ではなく direct 接続を推奨。
+      # pooler 経由は advisory lock 等でマイグレーションが詰まることがある。
+      - name: Run migrations
+        working-directory: ./my-app
+        run: npm run db:migrate
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -6,6 +6,14 @@ name: DB Migrate (Neon)
 # 適用先は environment ごとの同名 secret(DATABASE_URL) で切り替わる。
 # 手動実行(workflow_dispatch)も可能（実行したブランチに応じて適用先が決まる）。
 # 注: 列追加など加算的なマイグレーション前提。破壊的変更は手動運用で慎重に。
+#
+# 【再発防止の前提】マイグレーションは必ず後方互換（加算的）に保つこと。
+# この workflow と Vercel deploy は main マージで並走するため、
+# 「deploy 完了 → migrate 未完」の一瞬に新カラム参照コードが動くと、
+# カラム不整合（42703 等）が一時的に再発し得る。加算的マイグレーションであれば
+# migrate 完了後に自己回復するが、列リネーム/削除などの破壊的変更では復旧しない。
+# 破壊的変更を伴う場合は、merge 前に workflow_dispatch で migrate を先行させてから
+# コードをデプロイする運用とする。
 on:
   push:
     branches: [main, develop]

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,25 +1,29 @@
 name: DB Migrate (Neon)
 
-# drizzle/ 配下が変わった状態で main にマージされたら、本番 Neon に migrate を自動適用する。
-# 手動実行(workflow_dispatch)も可能。
+# drizzle/ 配下が変わった状態で main / develop にマージされたら、対応する Neon に migrate を自動適用する。
+#   - main    → Production 環境の DATABASE_URL（本番DB）
+#   - develop → Preview 環境の DATABASE_URL（dev DB）
+# 適用先は environment ごとの同名 secret(DATABASE_URL) で切り替わる。
+# 手動実行(workflow_dispatch)も可能（実行したブランチに応じて適用先が決まる）。
 # 注: 列追加など加算的なマイグレーション前提。破壊的変更は手動運用で慎重に。
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - "my-app/drizzle/**"
       - ".github/workflows/db-migrate.yml"
   workflow_dispatch:
 
-# 同時に複数のマイグレーションが走らないよう直列化する
+# 同時に複数のマイグレーションが走らないよう、適用先(ブランチ)ごとに直列化する
 concurrency:
-  group: db-migrate-production
+  group: db-migrate-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   migrate:
     runs-on: ubuntu-latest
-    environment: production
+    # main は Production、それ以外(develop 等)は Preview 環境の secret を使う
+    environment: ${{ github.ref_name == 'main' && 'Production' || 'Preview' }}
 
     steps:
       - name: Checkout repository
@@ -29,8 +33,9 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
+          echo "branch: ${{ github.ref_name }} / environment: ${{ github.ref_name == 'main' && 'Production' || 'Preview' }}"
           if [ -z "$DATABASE_URL" ]; then
-            echo "Error: DATABASE_URL secret is not set"
+            echo "Error: DATABASE_URL secret is not set in this environment"
             exit 1
           fi
           echo "DATABASE_URL is configured"

--- a/my-app/app/api/discord/route.ts
+++ b/my-app/app/api/discord/route.ts
@@ -261,6 +261,8 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       // feedback / common-message / timer 系は上の if/startsWith で return 済みのため、欠落は異常としてログする。
       const matchId = extractMatchId(firstCustomId, { warnIfMissing: true }) || ""
       console.log("Extracted match_id:", matchId)
+      // この行は LoL register（message_id を持つ）と 格ゲー order（match_id のみで message_id を持たない）で共用される。
+      // 後者では欠落が正常なため warnIfMissing は付けない（付けると格ゲー出場順送信のたびに誤検知ログが出る）。
       const messageId = extractMessageId(customId) || ""
 
       const channelId = interaction.channel_id || ""

--- a/my-app/app/api/discord/route.ts
+++ b/my-app/app/api/discord/route.ts
@@ -31,6 +31,19 @@ import {
   ApplicationCommandType,
 } from "discord-api-types/v10"
 
+// custom_id に match_id を必ず含むメッセージコンポーネントのアクション一覧（LoL / 格ゲー）。
+// ここに無いアクション（team-schedule 等）は match_id を持たないのが正常なので、欠落をログしない。
+const MATCH_ID_REQUIRED_ACTIONS = new Set<string>([
+  CLIENT_ACTIONS.LOL.OPEN_MODAL_RED_TEAM_REGISTER,
+  CLIENT_ACTIONS.LOL.OPEN_MODAL_BLUE_TEAM_REGISTER,
+  CLIENT_ACTIONS.LOL.CHECK_REGISTERED,
+  CLIENT_ACTIONS.LOL.RESET_REGISTERED,
+  CLIENT_ACTIONS.LOL.OPEN_MODAL_TIMER,
+  CLIENT_ACTIONS.FIGHTING.OPEN_MODAL_TEAM1_ORDER,
+  CLIENT_ACTIONS.FIGHTING.OPEN_MODAL_TEAM2_ORDER,
+  CLIENT_ACTIONS.FIGHTING.RESET_TEAM_ORDER,
+])
+
 async function disableRegisterButtonsMessage(messageId: string, channelId: string, matchId: string) {
   try {
     await editDiscordMessage(channelId, messageId, "✅ 両チームの入力が完了し、結果が発表されました", createProtectComponents(matchId, true))
@@ -118,7 +131,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       const customId = interaction.data.custom_id
       console.log("MESSAGE_COMPONENT custom_id:", customId)
       const [actionId] = customId.split("?")
-      const matchId = extractMatchId(customId) || ""
+      // match_id を custom_id に必ず含むアクション（LoL / 格ゲー）。
+      // これらで match_id が欠けていれば異常なのでログを出す。team-schedule 等は元々 match_id を持たず正常。
+      const requiresMatchId = MATCH_ID_REQUIRED_ACTIONS.has(actionId)
+      const matchId = extractMatchId(customId, { warnIfMissing: requiresMatchId }) || ""
       console.log("action:", actionId, "matchId:", matchId)
 
       // MENTION_REACTORSのセレクトメニュー処理（custom_idに":"が含まれるため特別処理）
@@ -227,7 +243,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         const channelId = interaction.channel_id || ""
         const guildId = interaction.guild_id || ""
         const userId = interaction.member?.user?.id || ""
-        const matchId = extractMatchId(customId) || ""
+        const matchId = extractMatchId(customId, { warnIfMissing: true }) || ""
 
         return handleSubmitTimer({ timeInput, message, channelId, guildId, userId, matchId })
       }
@@ -241,7 +257,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         firstCustomId = firstComponent.component.custom_id || ""
       }
       console.log("First custom_id:", firstCustomId)
-      const matchId = extractMatchId(firstCustomId) || ""
+      // ここに到達するのは match_id 必須の LoL register / 格ゲー order モーダルのみ。
+      // feedback / common-message / timer 系は上の if/startsWith で return 済みのため、欠落は異常としてログする。
+      const matchId = extractMatchId(firstCustomId, { warnIfMissing: true }) || ""
       console.log("Extracted match_id:", matchId)
       const messageId = extractMessageId(customId) || ""
 

--- a/my-app/app/api/discord/util/extractCustomIdParam.test.ts
+++ b/my-app/app/api/discord/util/extractCustomIdParam.test.ts
@@ -49,7 +49,7 @@ describe("warnIfMissing オプション", () => {
     expect(spy).not.toHaveBeenCalled()
   })
 
-  it("failure: 値が無く warnIfMissing 未指定なら（デフォルト）ログを出さない", () => {
+  it("success: 値が無く warnIfMissing 未指定なら（デフォルト）ログを出さない", () => {
     const spy = vi.spyOn(console, "error").mockImplementation(() => {})
     const result = extractMatchId("action?other_param=123")
     expect(result).toBeUndefined()

--- a/my-app/app/api/discord/util/extractCustomIdParam.test.ts
+++ b/my-app/app/api/discord/util/extractCustomIdParam.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi, afterEach } from "vitest"
 import { extractMatchId, extractMessageId, extractType } from "./extractCustomIdParam"
 
 describe("extractMatchId", () => {
@@ -34,5 +34,32 @@ describe("extractType", () => {
   it("failure: type が存在しない場合は undefined", () => {
     const result = extractType("action?other_param=bug")
     expect(result).toBeUndefined()
+  })
+})
+
+describe("warnIfMissing オプション", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("success: 値があれば warnIfMissing:true でもログを出さない", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const result = extractMatchId("action?match_id=123", { warnIfMissing: true })
+    expect(result).toBe("123")
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("failure: 値が無く warnIfMissing 未指定なら（デフォルト）ログを出さない", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const result = extractMatchId("action?other_param=123")
+    expect(result).toBeUndefined()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("failure: 値が無く warnIfMissing:true ならログを出す", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const result = extractMatchId("action?other_param=123", { warnIfMissing: true })
+    expect(result).toBeUndefined()
+    expect(spy).toHaveBeenCalledOnce()
   })
 })

--- a/my-app/app/api/discord/util/extractCustomIdParam.ts
+++ b/my-app/app/api/discord/util/extractCustomIdParam.ts
@@ -5,30 +5,36 @@
  * @param paramName - 抽出したいパラメータ名
  * @returns パラメータの値、見つからない場合は undefined
  */
-const extractParam = (customId: string, paramName: string): string | undefined => {
+// 未発見は正常な戻り値（このパラメータを持たない custom_id もある）ため、デフォルトはログを出さない。
+// 「このアクションでは必須」と分かっている呼び出し側だけ warnIfMissing を渡してエラーログを出す。
+type ExtractOptions = { warnIfMissing?: boolean }
+
+const extractParam = (customId: string, paramName: string, options?: ExtractOptions): string | undefined => {
   const params = new URLSearchParams(customId.split("?")[1] || "")
   const value = params.get(paramName)
 
   if (!value) {
-    console.error(`[extractParam] ${paramName} が抽出できませんでした: ${customId}`)
+    if (options?.warnIfMissing) {
+      console.error(`[extractParam] ${paramName} が抽出できませんでした: ${customId}`)
+    }
     return undefined
   }
 
   return value
 }
 
-export const extractMatchId = (customId: string): string | undefined => {
-  return extractParam(customId, "match_id")
+export const extractMatchId = (customId: string, options?: ExtractOptions): string | undefined => {
+  return extractParam(customId, "match_id", options)
 }
 
-export const extractMessageId = (customId: string): string | undefined => {
-  return extractParam(customId, "message_id")
+export const extractMessageId = (customId: string, options?: ExtractOptions): string | undefined => {
+  return extractParam(customId, "message_id", options)
 }
 
-export const extractType = (customId: string): string | undefined => {
-  return extractParam(customId, "type")
+export const extractType = (customId: string, options?: ExtractOptions): string | undefined => {
+  return extractParam(customId, "type", options)
 }
 
-export const extractInviteToken = (customId: string): string | undefined => {
-  return extractParam(customId, "invite")
+export const extractInviteToken = (customId: string, options?: ExtractOptions): string | undefined => {
+  return extractParam(customId, "invite", options)
 }


### PR DESCRIPTION
## 背景

チーム招待コマンドからの参加が「参加処理に失敗しました。」で失敗していた。原因は本番Neonにマイグレーション `0003`（`team_members.invited_by` 列追加）が適用されておらず、`joinAsMember` の INSERT が `column "invited_by" does not exist`（42703）でクラッシュしていたこと。コードのカラム名ミスではなく、**マイグレーション適用漏れ**。

調査中のログで `team-schedule-join` 等の custom_id に対し `[extractParam] match_id が抽出できませんでした` という誤検知エラーログがノイズになっていることも判明。

## 変更内容

### 1. ci: 自動マイグレーション（main / develop）
- `my-app/drizzle/**` が変わった状態で push されたら `db:migrate` を自動適用する GitHub Actions を追加（`workflow_dispatch` で手動実行も可）。
- **適用先をブランチで切り替え**: `main → Production` 環境 / `develop → Preview` 環境。各環境の同名 `DATABASE_URL` secret（本番DB / dev DB）を使う。
- `concurrency` をブランチごとに分けて多重実行を直列化（dev/本番が互いをブロックしない）。`DATABASE_URL` secret の存在を事前検証。
- 適用漏れによる本事象の**再発防止**が目的。

### 2. fix: custom_id パラメータ欠落ログを必須時のみに限定
- `extractCustomIdParam` に `warnIfMissing` オプションを追加。デフォルトは無言で `undefined` を返す（未発見は正常な戻り値）。
- `match_id` が構造上必須なアクション（LoL register/timer・格ゲー order）の呼び出しだけ `warnIfMissing: true` を渡し、**本当の欠落は従来どおりログに残す**。`team-schedule-join` 等のノイズだけ消える。
- `warnIfMissing` の挙動を検証するテストを追加。

## 検討済みの判断（再指摘防止のため明文化）
- **タイミング**: GitHub Actions(migrate) と Vercel(deploy) は並走する。加算的マイグレーション前提なら実害は出にくい。**破壊的変更（列リネーム/削除）は自動に任せず手動運用**する方針を workflow 冒頭コメントに明記。
- **接続文字列**: 各環境の `DATABASE_URL` は pooled(`-pooler`) ではなく **direct 接続を推奨**（pooler は advisory lock 等で migrate が詰まる）。
- **MODAL_SUBMIT のフォールスルー**: `warnIfMissing:true` の箇所には match_id 必須モーダルしか到達しない（feedback等は手前で return）ことをコード追跡で確認済み。

## デプロイ後の必須セットアップ（このPRだけでは障害は直りません）
現状 GitHub 環境は secret 未整備（`Production` に DB secret 無し / `Preview` は空 / 誤って環境名 `DATABASE_URL` が存在）。以下が必要:
1. `Production` 環境に Secret `DATABASE_URL`（**本番Neon**・direct接続推奨）を登録
2. `Preview` 環境に Secret `DATABASE_URL`（**dev Neon**・direct接続推奨）を登録
3. 誤って作られた環境 `DATABASE_URL` を削除（混乱防止）
4. main 側の障害解消は、1 の登録後に Actions から `DB Migrate` を main で手動実行 → `0003` 適用
5. **`Production` 環境に Required reviewers（承認ゲート）を設定**（推奨）
   - 本 workflow は main への push で `drizzle/**` が変わると本番DBへ無人で migrate を適用する。誤った/破壊的なマイグレーションがレビューなしで本番直行するのを防ぐため、GitHub の `Production` 環境に承認者を設定し、本番 migrate を手動承認待ちで止める。
   - 設定: Settings → Environments → `Production` → "Required reviewers"

## 確認
- [x] `npm run lint` クリーン
- [x] `npx tsc --noEmit` クリーン
- [x] 対象テスト 9件 pass（うち1件はタイトルを success: に訂正）
- [x] fresh-eyes セルフレビュー（must 指摘なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
