### PR TITLE
feat: チーム招待リンク/参加済み案内に team= を付与し着地後に自チーム選択 (#133, #134)

### DIFF
--- a/.claude/feedback/log.md
+++ b/.claude/feedback/log.md
@@ -41,3 +41,11 @@
 セルフレビューは「diff 内部の自己整合性」は見るが「diff 外の前提（外部API契約・認証/セッション寿命・グローバル状態の寿命）」の裏取りを飛ばしがち。
 → 仕組み化案: コミット前チェックに「①コメント/前提が外部モジュールの挙動に依存していないか。していれば該当コードを読んで裏取りしたか ②module-levelの可変状態を足したらログアウト/別ユーザー/別タブで評価したか」を追加する。
 -->
+
+## 2026-06-17: useCallback の deps に searchParams を入れ、effect 再実行リスクを作った（#134）
+
+**カテゴリ**: code-quality
+**状況**: team_schedules で token/join のURL掃除時に team= を残すヘルパー `cleanUrlKeepingTeam` を `useCallback` で作り、`searchParams` を deps に入れた。そのヘルパーを `?token=` / `?join=` の useEffect の依存配列に含めた。
+**ミス**: `useSearchParams()` の戻り値はクエリ変更時に同一性が変わるため、`cleanUrlKeepingTeam` の参照も変わり、依存する effect が再実行され得る。特に verifyMagicLink を含む token effect が pending 中に再実行されると二重呼び出しになる。既存コードは `token`/`joinToken` を**文字列に落として** deps にしており（searchParams オブジェクトを避ける流儀）、そこと不一致だった。
+**正解**: effect/コールバックの deps には searchParams オブジェクトそのものを入れない。(1) 必要な値は文字列に派生させて deps にする、(2) 掃除系コールバックは呼び出し時点で `window.location.search` を読み、deps は安定参照（router）だけにする。「ガードフラグ(ref)」も、`router.replace` でクエリが消えれば次回 early-return する設計なら不要。
+**なぜセルフレビューで見つからなかったか**: 自分の差分内（team= を残すロジック）の正しさは確認したが、**既存 effect の deps 設計の流儀（searchParams を避け文字列派生する）に揃っているか**という一貫性チェックを飛ばした。fresh-eyes エージェントが既存パターンとの差分として拾った。

--- a/my-app/app/api/discord/command/team-schedule/invite.ts
+++ b/my-app/app/api/discord/command/team-schedule/invite.ts
@@ -21,6 +21,12 @@ import { redisGet } from "@/app/_server/lib/redis/redis"
 import { editWebhookOriginalMessage, createFollowupMessage } from "@/app/_server/lib/discord/api"
 import { CLIENT_ACTIONS } from "@/app/_server/util/commands"
 import { extractInviteToken } from "@/app/api/discord/util/extractCustomIdParam"
+import { APP_URL } from "@/app/_server/lib/env"
+
+/** 対象チームを自チーム選択した状態でチームスケジュール画面を開くURL（クエリは画面側で読み取る） */
+function teamSchedulesUrl(teamId: string): string {
+  return `${APP_URL}/team_schedules?team=${encodeURIComponent(teamId)}`
+}
 
 /** チーム情報（名前表示用の最小限） */
 type TeamRef = { teamId: string; name: string }
@@ -279,7 +285,11 @@ export function handleJoinButton(interaction: APIMessageComponentInteraction): N
         .where(eq(teamMembers.userId, userId))
 
       if (myTeams.some((t) => t.teamId === team.teamId)) {
-        return safeEdit(application_id, interactionToken, `すでに「${team.name}」に参加済みです。`)
+        return safeEdit(
+          application_id,
+          interactionToken,
+          `すでに「${team.name}」に参加済みです。\nスケジュールはこちら → ${teamSchedulesUrl(team.teamId)}`,
+        )
       }
 
       // 別チームに所属している場合は追加加入の確認を出す（抜けずに追加）

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.ts
@@ -31,7 +31,9 @@ export async function POST(req: NextRequest, ctx: RouteContext): Promise<NextRes
 
     const token = await createInviteToken(teamId, userId)
 
-    const url = `${APP_URL}/team_schedules?join=${token}`
+    // join= で参加させつつ、team= で着地後に対象チームを自チーム選択させる。
+    // （未参加→参加でも、既に参加済みでも、同じリンクから対象チームが選択される導線になる）
+    const url = `${APP_URL}/team_schedules?join=${token}&team=${encodeURIComponent(teamId)}`
     const expiryDays = Math.round(INVITE_TTL / (60 * 60 * 24))
     return NextResponse.json({ success: true, url, expiryDays })
   } catch (error) {

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -57,6 +57,17 @@ export function TeamSchedulesPage() {
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState(false)
 
+  // token / join を URL から消す際、対象チーム選択用の team= だけは残して掃除する。
+  // 招待リンク（?join=...&team=...）は join を消費しても team を後段の効果で読み取る必要があるため、
+  // 一括で全クエリを消す router.replace は使わない。team が無ければ素のパスに戻す。
+  // 呼び出し時点の最新クエリを window.location から読む（searchParams を deps に入れると
+  // この関数の同一性が毎レンダリングで変わり、token/join 効果が再実行され verifyMagicLink が
+  // 二重呼び出しされ得るため）。router は安定参照。
+  const cleanUrlKeepingTeam = useCallback(() => {
+    const t = new URLSearchParams(window.location.search).get("team")
+    router.replace(t ? `/team_schedules?team=${encodeURIComponent(t)}` : "/team_schedules")
+  }, [router])
+
   // ログイン着地: URLに ?token= があれば magic-link を検証してセッションを確立し、URLを掃除する
   const token = searchParams.get("token")
   useEffect(() => {
@@ -72,13 +83,13 @@ export function TeamSchedulesPage() {
       })
       .finally(() => {
         if (cancelled) return
-        // トークンをURLから除去（再読込・共有時の誤用を防ぐ）
-        router.replace("/team_schedules")
+        // トークンをURLから除去（再読込・共有時の誤用を防ぐ）。team= は残す。
+        cleanUrlKeepingTeam()
       })
     return () => {
       cancelled = true
     }
-  }, [token, router])
+  }, [token, cleanUrlKeepingTeam])
 
   // 招待リンク着地: ?join= があれば参加トークンを sessionStorage に退避し、URLを掃除する。
   // （未ログインならログイン往復をまたぐため、ログイン後に実行する）
@@ -90,8 +101,9 @@ export function TeamSchedulesPage() {
     } catch {
       // sessionStorage が使えない環境ではこの後の参加処理が走らないだけ
     }
-    router.replace("/team_schedules")
-  }, [joinToken, router])
+    // join は消すが team= は残し、後段の ?team= 効果で対象チームを自チーム選択させる
+    cleanUrlKeepingTeam()
+  }, [joinToken, cleanUrlKeepingTeam])
 
   // 初期ロード: セッション + チーム一覧
   useEffect(() => {
@@ -128,6 +140,21 @@ export function TeamSchedulesPage() {
     if (nextOwn === ownTeamId && nextOpponents.length === opponentTeamIds.length) return
     setStoredSelection({ ownTeamId: nextOwn, opponentTeamIds: nextOpponents })
   }, [loading, teams, ownTeamId, opponentTeamIds])
+
+  // 「参加済み」案内リンク・招待リンクからの着地: ?team=<teamId> があれば、そのチームを自チームに選択する。
+  // （Discord の招待ボタンで既に参加済みだったユーザーをスケジュール画面に誘導する導線）
+  // チーム一覧（public read で全チーム返す）の取得後に存在チェックし、setOwnTeamId 経由で
+  // localStorage にも永続化する。最後に URL から team= を消すため teamParam が null になり、
+  // 再実行時は冒頭で早期 return する＝自然に一度きりの処理になる（専用のガードフラグは不要）。
+  const teamParam = searchParams.get("team")
+  useEffect(() => {
+    if (!teamParam || loading) return
+    // 存在しない（削除済み等）チームIDは無視し、URLだけ掃除する
+    if (teams.some((t) => t.teamId === teamParam)) {
+      setOwnTeamId(teamParam)
+    }
+    router.replace("/team_schedules")
+  }, [teamParam, loading, teams, setOwnTeamId, router])
 
   // 選択中チームの予定を取得
   useEffect(() => {

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -144,7 +144,8 @@ export function TeamSchedulesPage() {
   // 「参加済み」案内リンク・招待リンクからの着地: ?team=<teamId> があれば、そのチームを自チームに選択する。
   // （Discord の招待ボタンで既に参加済みだったユーザーをスケジュール画面に誘導する導線）
   // チーム一覧（public read で全チーム返す）の取得後に存在チェックし、setOwnTeamId 経由で
-  // localStorage にも永続化する。最後に URL から team= を消すため teamParam が null になり、
+  // localStorage にも永続化する。既に別チームが own 選択済みでも team= で上書きする（招待/誘導が優先）。
+  // 最後に URL から team= を消すため teamParam が null になり、
   // 再実行時は冒頭で早期 return する＝自然に一度きりの処理になる（専用のガードフラグは不要）。
   const teamParam = searchParams.get("team")
   useEffect(() => {


### PR DESCRIPTION
## 概要

チーム招待リンク・「参加済み」案内に `team=<teamId>` クエリを付与し、着地後に対象チームを自チーム（own）選択するようにした。

Closes #133
Closes #134
親issue: #94

## 変更内容

- **招待リンク** ([invite/route.ts](my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.ts)): `?join=<token>` → `?join=<token>&team=<teamId>` に変更
- **Discord「参加済み」レスポンス** ([invite.ts](my-app/app/api/discord/command/team-schedule/invite.ts)): 既に参加済みのユーザーにスケジュール画面URL（`?team=<teamId>`）を併記
- **着地ページ** ([TeamSchedulesPage.tsx](my-app/app/team_schedules/_components/TeamSchedulesPage.tsx)):
  - `?team=` を読み取り、チーム一覧に存在すれば `setOwnTeamId` で自チーム選択 → localStorage に永続化
  - `?token=`(magic-link) / `?join=` のURL掃除時に `team=` だけ残す `cleanUrlKeepingTeam` を追加

## 設計上の判断（明文化）

- **`cleanUrlKeepingTeam` は `window.location.search` を読む**: `useSearchParams()` の戻り値を useCallback の deps に入れるとクエリ変更のたびに同一性が変わり、依存する effect が再実行され `verifyMagicLink` 二重呼び出しの恐れがあるため。deps は安定参照の `router` のみ。
- **`?team=` 効果はガードフラグ不要**: 処理後 `router.replace` で `team=` を消すと teamParam が null になり、再実行時は冒頭で早期 return する＝自然に一度きりになる。
- **magic-link 往復をまたいでも維持**: 未ログイン時は先に `?join=&team=` 着地で own 選択が localStorage に永続化されるため、`?token=` のみの magic-link 着地を経ても選択は残る。
- **`team=` の権限**: クエリは own 選択に流すだけ。teams API は public read（全チーム返す）なので、共有されても閲覧範囲以上の権限は得られない。

## 確認

- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- 招待ルートのテスト（4件）✅
- fresh-eyes セルフレビュー実施・指摘反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
