### PR TITLE
feat: チーム単位モードのセルを状態別に強調 + md以下でカレンダーのみスクロール

### DIFF
--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -205,7 +205,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
                   // team 列は bg を状態強調に使うため indigo bg は敷かない（編集可は下の ring で表現）
                   let cellBg = pinned ? bg : editableMember && !isTeamCol ? "bg-indigo-950/40" : ""
                   // チーム単位モード列は、その日のセル状態に応じてセル全体を強調する（○=bg を上書き / ×=中身を薄く）。
-                  // ○の強調 bg は半透明（成立/詰みの行背景と同種）。ピン留め相手team列でも視認性優先で行背景より優先する。
+                  // ○の強調 bg は半透明（成立行の背景 emerald/30 と同種）。ピン留め相手team列でも視認性優先で行背景より優先する。
                   const emphasis = isTeamCol ? teamCellEmphasis(schedCol!.cells.get(r.date.key)?.status ?? "none") : null
                   if (emphasis?.bg) cellBg = emphasis.bg
                   // 編集可能な team 列は bg を状態強調に使うため、編集可インジケータは ring（枠線）で表現する（bg と両立）

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -107,7 +107,16 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
         const view = col.cells.get(day) ?? { status: "none" as CellStatus, note: "" }
         const handlers = cellHandlers(col, day, view.status)
         // team モードはセル全体を opacity-30 で薄くするため（td側）、ボタン単体の dim は二重適用を避けて付けない
-        return <ScheduleCell status={view.status} note={view.note} editable={col.editable} dim={col.kind !== "team" && view.status === "ng"} onCycle={handlers.onCycle} onNoteChange={handlers.onNoteChange} />
+        return (
+          <ScheduleCell
+            status={view.status}
+            note={view.note}
+            editable={col.editable}
+            dim={col.kind !== "team" && view.status === "ng"}
+            onCycle={handlers.onCycle}
+            onNoteChange={handlers.onNoteChange}
+          />
+        )
       },
     }))
 
@@ -116,11 +125,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
       header: "成立",
       size: SIZE.success,
       cell: ({ row }) =>
-        row.original.success ? (
-          <span className="inline-block rounded bg-emerald-600 px-1.5 py-0.5 text-[11px] font-bold text-white">成立</span>
-        ) : (
-          <span className="text-xs text-zinc-600">—</span>
-        ),
+        row.original.success ? <span className="inline-block rounded bg-emerald-600 px-1.5 py-0.5 text-[11px] font-bold text-white">成立</span> : <span className="text-xs text-zinc-600">—</span>,
     }
 
     const memberCols: ColumnDef<GridRow>[] = memberColumns.map((col) => ({
@@ -193,22 +198,27 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
                 {row.getVisibleCells().map((cell) => {
                   const col = cell.column
                   const pinned = col.getIsPinned() === "left"
+                  const schedCol = columnById.get(col.id)
+                  const isTeamCol = schedCol?.kind === "team"
                   const editableMember = memberColumns.find((c) => c.id === col.id)?.editable
-                  // ピン留め列（日付・○数・相手・成立）は行背景を敷く。自メンバー列は編集中のみハイライト
-                  let cellBg = pinned ? bg : editableMember ? "bg-indigo-950/40" : ""
+                  // ピン留め列（日付・○数・相手・成立）は行背景を敷く。自メンバー列は編集中のみハイライト。
+                  // team 列は bg を状態強調に使うため indigo bg は敷かない（編集可は下の ring で表現）
+                  let cellBg = pinned ? bg : editableMember && !isTeamCol ? "bg-indigo-950/40" : ""
                   // チーム単位モード列は、その日のセル状態に応じてセル全体を強調する（○=明るく / ×=薄く）。
                   // ピン留めされた相手team列でも、視認性を優先して行背景（成立/詰み）より強調色を優先する。
-                  const schedCol = columnById.get(col.id)
-                  const emphasis = schedCol?.kind === "team" ? teamCellEmphasis(schedCol.cells.get(r.date.key)?.status ?? "none") : null
+                  const emphasis = isTeamCol ? teamCellEmphasis(schedCol!.cells.get(r.date.key)?.status ?? "none") : null
                   if (emphasis?.bg) cellBg = emphasis.bg
-                  const faded = emphasis?.faded ? " opacity-30" : ""
+                  // 編集可能な team 列は bg を状態強調に使うため、編集可インジケータは ring（枠線）で表現する（bg と両立）
+                  const teamEditRing = isTeamCol && schedCol!.editable ? " ring-1 ring-inset ring-indigo-500/50" : ""
+                  // × セルは中身だけ薄くする。td 自体の bg は不透明のまま（sticky セルの背後透け防止）
+                  const content = flexRender(col.columnDef.cell, cell.getContext())
                   return (
                     <td
                       key={cell.id}
-                      className={"border-b border-r border-zinc-700 px-1.5 py-1.5 align-top text-center " + cellBg + faded}
+                      className={"border-b border-r border-zinc-700 px-1.5 py-1.5 align-top text-center " + cellBg + teamEditRing}
                       style={{ ...pinnedStyle(col, false), minWidth: col.getSize(), width: pinned ? col.getSize() : undefined }}
                     >
-                      {flexRender(col.columnDef.cell, cell.getContext())}
+                      {emphasis?.faded ? <div className="opacity-30">{content}</div> : content}
                     </td>
                   )
                 })}

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -204,13 +204,13 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
                   // ピン留め列（日付・○数・相手・成立）は行背景を敷く。自メンバー列は編集中のみハイライト。
                   // team 列は bg を状態強調に使うため indigo bg は敷かない（編集可は下の ring で表現）
                   let cellBg = pinned ? bg : editableMember && !isTeamCol ? "bg-indigo-950/40" : ""
-                  // チーム単位モード列は、その日のセル状態に応じてセル全体を強調する（○=明るく / ×=薄く）。
-                  // ピン留めされた相手team列でも、視認性を優先して行背景（成立/詰み）より強調色を優先する。
+                  // チーム単位モード列は、その日のセル状態に応じてセル全体を強調する（○=bg を上書き / ×=中身を薄く）。
+                  // ○の強調 bg は半透明（成立/詰みの行背景と同種）。ピン留め相手team列でも視認性優先で行背景より優先する。
                   const emphasis = isTeamCol ? teamCellEmphasis(schedCol!.cells.get(r.date.key)?.status ?? "none") : null
                   if (emphasis?.bg) cellBg = emphasis.bg
                   // 編集可能な team 列は bg を状態強調に使うため、編集可インジケータは ring（枠線）で表現する（bg と両立）
                   const teamEditRing = isTeamCol && schedCol!.editable ? " ring-1 ring-inset ring-indigo-500/50" : ""
-                  // × セルは中身だけ薄くする。td 自体の bg は不透明のまま（sticky セルの背後透け防止）
+                  // × セルは td の bg は変えず（行背景のまま）、中身だけ opacity-30 で薄くする
                   const content = flexRender(col.columnDef.cell, cell.getContext())
                   return (
                     <td

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -31,6 +31,16 @@ function rowBgClass(row: GridRow): string {
   return "bg-zinc-900"
 }
 
+/**
+ * チーム単位モード列のセル全体を状態別に強調する（他チームからの視認性向上）。
+ * ○: 背景を少し明るく / ×: セル全体を薄く（opacity 30）。△・未記入は通常表示。
+ */
+function teamCellEmphasis(status: CellStatus): { bg: string | null; faded: boolean } {
+  if (status === "ok") return { bg: "bg-emerald-900/40", faded: false }
+  if (status === "ng") return { bg: null, faded: true }
+  return { bg: null, faded: false }
+}
+
 /** ピン留めされた列の sticky スタイルを返す */
 function pinnedStyle(column: Column<GridRow>, isHeader: boolean): React.CSSProperties | undefined {
   if (column.getIsPinned() !== "left") return undefined
@@ -96,7 +106,8 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
         const day = row.original.date.key
         const view = col.cells.get(day) ?? { status: "none" as CellStatus, note: "" }
         const handlers = cellHandlers(col, day, view.status)
-        return <ScheduleCell status={view.status} note={view.note} editable={col.editable} dim={view.status === "ng"} onCycle={handlers.onCycle} onNoteChange={handlers.onNoteChange} />
+        // team モードはセル全体を opacity-30 で薄くするため（td側）、ボタン単体の dim は二重適用を避けて付けない
+        return <ScheduleCell status={view.status} note={view.note} editable={col.editable} dim={col.kind !== "team" && view.status === "ng"} onCycle={handlers.onCycle} onNoteChange={handlers.onNoteChange} />
       },
     }))
 
@@ -129,6 +140,14 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
 
   const leftPinned = useMemo(() => ["date", "count", ...opponentColumns.map((c) => `opp:${c.teamId}`), "success"], [opponentColumns])
 
+  // td の className 算出でセル状態を引くための、テーブル列ID → ScheduleColumn の対応表。
+  // opponent/member いずれも ScheduleColumn.id がテーブル列IDと一致する（opp:teamId / own:userId など）。
+  const columnById = useMemo(() => {
+    const m = new Map<string, ScheduleColumn>()
+    for (const c of [...opponentColumns, ...memberColumns]) m.set(c.id, c)
+    return m
+  }, [opponentColumns, memberColumns])
+
   // TanStack Table の useReactTable は関数を返すため React Compiler でメモ化されない
   // （既知のライブラリ制約。動作には影響しないため抑制する）
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -140,7 +159,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
   })
 
   return (
-    <div className="overflow-auto rounded-lg border border-zinc-700 bg-zinc-900">
+    <div className="h-full min-w-0 overflow-auto rounded-lg border border-zinc-700 bg-zinc-900 lg:h-auto">
       <table className="border-collapse text-sm">
         <thead>
           {table.getHeaderGroups().map((hg) => (
@@ -176,11 +195,17 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
                   const pinned = col.getIsPinned() === "left"
                   const editableMember = memberColumns.find((c) => c.id === col.id)?.editable
                   // ピン留め列（日付・○数・相手・成立）は行背景を敷く。自メンバー列は編集中のみハイライト
-                  const cellBg = pinned ? bg : editableMember ? "bg-indigo-950/40" : ""
+                  let cellBg = pinned ? bg : editableMember ? "bg-indigo-950/40" : ""
+                  // チーム単位モード列は、その日のセル状態に応じてセル全体を強調する（○=明るく / ×=薄く）。
+                  // ピン留めされた相手team列でも、視認性を優先して行背景（成立/詰み）より強調色を優先する。
+                  const schedCol = columnById.get(col.id)
+                  const emphasis = schedCol?.kind === "team" ? teamCellEmphasis(schedCol.cells.get(r.date.key)?.status ?? "none") : null
+                  if (emphasis?.bg) cellBg = emphasis.bg
+                  const faded = emphasis?.faded ? " opacity-30" : ""
                   return (
                     <td
                       key={cell.id}
-                      className={"border-b border-r border-zinc-700 px-1.5 py-1.5 align-top text-center " + cellBg}
+                      className={"border-b border-r border-zinc-700 px-1.5 py-1.5 align-top text-center " + cellBg + faded}
                       style={{ ...pinnedStyle(col, false), minWidth: col.getSize(), width: pinned ? col.getSize() : undefined }}
                     >
                       {flexRender(col.columnDef.cell, cell.getContext())}

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -493,11 +493,14 @@ export function TeamSchedulesPage() {
     return { memberColumns, opponentColumns, rows, threshold }
   }, [ownTeamId, opponentTeamIds, schedulesByTeam, dates, dayKeys, session])
 
+  // md以下（lg未満）はヘッダー＋body を画面内に収め、カレンダー（グリッド）だけスクロールさせる。lg以上は通常のページスクロール。
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100">
-      <LolHeader userName={session?.displayName ?? null} onLogin={openLogin} />
-      <div className="mx-auto max-w-6xl p-3 sm:p-6">
-        <div className="flex flex-wrap items-start justify-between gap-2">
+    <div className="flex h-dvh flex-col overflow-hidden bg-zinc-950 text-zinc-100 lg:block lg:h-auto lg:min-h-screen lg:overflow-visible">
+      <div className="shrink-0">
+        <LolHeader userName={session?.displayName ?? null} onLogin={openLogin} />
+      </div>
+      <div className="mx-auto flex min-h-0 w-full max-w-6xl flex-1 flex-col p-3 sm:p-6 lg:block">
+        <div className="flex shrink-0 flex-wrap items-start justify-between gap-2">
           <div>
             <h1 className="text-lg font-bold tracking-tight text-zinc-100">チーム活動 スケジュール調整</h1>
             <p className="mt-0.5 text-sm text-zinc-400">必要人数そろって、相手も空いてる日を探す</p>
@@ -521,12 +524,12 @@ export function TeamSchedulesPage() {
         </div>
 
         {loadError && (
-          <div className="mt-3 rounded-lg border border-rose-800 bg-rose-950/50 px-3 py-2 text-xs text-rose-300">
+          <div className="mt-3 shrink-0 rounded-lg border border-rose-800 bg-rose-950/50 px-3 py-2 text-xs text-rose-300">
             データの読み込みに失敗しました。時間をおいて再読み込みしてください。
           </div>
         )}
 
-        <div className="mt-3 flex flex-col gap-3">
+        <div className="mt-3 flex shrink-0 flex-col gap-3">
           <TeamCompareSelector
             teams={teams}
             ownTeamId={ownTeamId}
@@ -537,7 +540,7 @@ export function TeamSchedulesPage() {
           {view && <ControlBar threshold={view.threshold} />}
         </div>
 
-        <div className="mt-3">
+        <div className="mt-3 flex min-h-0 flex-1 flex-col overflow-hidden lg:block lg:flex-none lg:overflow-visible">
           {loading ? (
             <p className="text-sm text-zinc-400">読み込み中…</p>
           ) : !view ? (
@@ -558,7 +561,7 @@ export function TeamSchedulesPage() {
           )}
         </div>
 
-        <p className="mt-3 text-xs leading-relaxed text-zinc-400">
+        <p className="mt-3 max-h-24 shrink-0 overflow-y-auto text-xs leading-relaxed text-zinc-400 lg:max-h-none lg:overflow-visible">
           ※ セルをタップで 未記入→○→△→× を循環。○数が必要人数以上かつ相手が空いている日が「成立」。×が増えて必要人数に届かない確定の日は行を薄く表示。相手の不可セルは薄く表示。チーム単位モードのチームは管理者が1列でまとめて入力します。時間は自由記入のため、○数は時間の重なりまでは見ていません。
         </p>
       </div>


### PR DESCRIPTION
## 概要

チーム活動スケジュール調整（`/team_schedules`）の表示を2点改善する。

1. **チーム単位モード列のセル強調**（Closes #135）
2. **md以下でのレイアウト固定**（ヘッダー＋body を画面内に収め、カレンダーだけスクロール）

## 変更内容

### 1. チーム単位モード列のセルを状態別に強調

チーム単位管理モード（`kind === "team"`）の列を、他チームから一目で空き状況が判別しやすいようセル全体（`<td>`）を強調する。

| 状態 | セル全体の見た目 |
| --- | --- |
| ○ ok | 背景を少し明るく（`bg-emerald-900/40`） |
| × ng | セル全体を薄く（`opacity-30`） |
| △ / – | 現状どおり |

- 自チーム列・相手チーム列の両方のチーム単位モードに適用。
- 二重 dim を避けるため、team 列ではボタン単体の `dim`（`opacity-40`）を外した。

### 2. md以下（lg未満）でカレンダーのみスクロール

- ルートを `h-dvh + flex flex-col + overflow-hidden` にして画面全体を viewport 高さに固定。
- ヘッダー・タイトル・セレクター・注記を `shrink-0` の固定領域に、グリッド領域を `flex-1 + min-h-0` にして、カレンダー（グリッド）だけが縦横スクロールするようにした。
- lg以上は `lg:block` 等で従来どおりのページ全体スクロールに戻す。

## 設計上の判断（明文化）

- ピン留めされた相手 team 列の○セルは、視認性を優先して行背景（成立/詰み）より強調色を上書きする（コードコメントに記載）。
- 注記文は小画面で `max-h-24 + overflow-y-auto` にし、伸びてグリッドを潰さないよう内部スクロールにした。

## 確認

- `npm run lint` / `npx tsc --noEmit` ともにクリーン。
- fresh-eyes レビューを実施し、`columnById` のキー一致（correctness）を裏取り済み。横スクロール保証のため overflow コンテナに `min-w-0` を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)