### PR TITLE
fix: 個人の日付メモ入力でフォーカスが外れる不具合を修正 (#127)

### DIFF
--- a/my-app/app/team_schedules/_components/ScheduleCell.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleCell.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import type { CellStatus } from "../_types"
 import { STATUS_STYLE } from "../_utils"
 
@@ -16,6 +17,24 @@ type ScheduleCellProps = {
 /** 状態トグルボタン + 時間メモ欄のセル */
 export function ScheduleCell({ status, note, editable, dim = false, onCycle, onNoteChange }: ScheduleCellProps) {
   const style = STATUS_STYLE[status]
+
+  // 入力中に親 state（schedulesByTeam）を更新するとグリッド全体が再計算・再マウントされ、
+  // input のフォーカスが外れてしまう（#127）。そのため入力中はローカル state で文字を保持し、
+  // blur 時にまとめて親へ反映する。これで毎キーの再描画と upsert API 呼び出しも防げる。
+  const [draft, setDraft] = useState(note)
+  // 親側 note の変化（状態トグル・チーム切替・外部更新等）にローカル値を同期する。
+  // effect ではなく render 中に前回値と比較する React 公式推奨パターン。
+  // 入力中は note prop が変わらない（コミットは blur 時のみ）ため、打鍵を上書きすることはない。
+  const [prevNote, setPrevNote] = useState(note)
+  if (note !== prevNote) {
+    setPrevNote(note)
+    setDraft(note)
+  }
+
+  const commitNote = () => {
+    // 未編集なら余計な POST・再描画を避ける
+    if (draft !== note) onNoteChange?.(draft)
+  }
 
   return (
     <div className="text-center">
@@ -37,8 +56,15 @@ export function ScheduleCell({ status, note, editable, dim = false, onCycle, onN
         // 状態が未記入のうちはメモを保存する行が無いため、入力欄を非活性にする
         // （○/△/× を付けてから時間を書く運用。none のまま打っても破棄されるのを防ぐ）
         <input
-          value={note}
-          onChange={(e) => onNoteChange?.(e.target.value)}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          // ボタン押下時はクリックより先に blur が発火するため、状態トグル前に必ずコミットされる
+          onBlur={commitNote}
+          // Enter で確定（blur を促してコミットする）。
+          // IME 変換確定の Enter（isComposing 中）は対象外にする（日本語入力を中断しないため）
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.nativeEvent.isComposing) e.currentTarget.blur()
+          }}
           disabled={status === "none"}
           placeholder="時間"
           className={


### PR DESCRIPTION
## 概要

`/team_schedules` の個人メモ（時間メモ）入力欄で、1文字打つと毎回フォーカスが外れて連続入力できない不具合 (#127) を修正します。日本語入力・半角どちらでも発生していました。

Closes #127

## 原因

メモ入力は controlled input で、1キーごとに `onChange → handleNoteChange → applyLocalEdit → setSchedulesByTeam` が走っていた。この親 state 更新が `TeamSchedulesPage` の `view` useMemo を再計算させ、`memberColumns`/`opponentColumns` が新しい参照に → `ScheduleGrid` の `columns` useMemo が再生成 → 各列の `cell:` アロー関数の同一性が変化。`flexRender` はこの関数を**コンポーネント型**として `createElement` するため、型が変わると React が input を unmount+remount し、DOM が作り直されてフォーカスを失っていた（TanStack Table v8 の既知の落とし穴）。

引き金は POST(`persist`) ではなく、毎キーの `applyLocalEdit`（= `setSchedulesByTeam`）による再描画。

## 修正

入力中は `ScheduleCell` の**ローカル state(`draft`)** で文字を保持し、親へは **blur / Enter 時に1回だけ**反映する。入力中は親 state を触らないため `view`/`columns` が再計算されず、再マウントが起きずフォーカスが保たれる。副次的に、現状の「毎キー upsert POST（debounce 無し）」も blur 時1回に集約される。

変更は `ScheduleCell.tsx` のみ（`ScheduleGrid.tsx` / `TeamSchedulesPage.tsx` は変更なし）。

## 検討・トレードオフ（settled）

- **prop 同期は render 中の前回値比較**（`if (note !== prevNote) { setPrevNote; setDraft }`）。React 公式 "You Might Not Need an Effect" の推奨パターン。`useEffect` 版は `react-hooks/set-state-in-effect` で弾かれるため不採用。
- **入力途中に状態ボタン(○/△/×)を押しても draft は失われない**。ブラウザは `blur`→`click` の順で発火し、React は別 discrete event 間で state をフラッシュするため、`handleCycle` の `currentNote` はコミット後の値を読む（save-on-blur の標準挙動）。
- **Enter 確定は IME 変換中(`isComposing`)を除外**。日本語入力の変換確定 Enter で誤って blur／中断しないため。
- **columns 安定化リファクタ（cell データを GridRow に流す案）は不採用**。再マウントを構造的に解消できるが `_types.ts`/`view`/ハンドラ署名/ScheduleGrid に波及し差分大。本アプリにリアルタイム更新は無く、自分の打鍵中に他要因で `schedulesByTeam` が変わらないため、ローカル state + blur コミットで実用上十分かつ最小。

## 確認

- `npm run lint` ✅ / `npx tsc --noEmit` ✅
- 手動確認（推奨）: 自チーム選択 → ○/△/× を付与 → 時間メモを連続入力できる（日本語入力含む）／blur・Enter で保存（リロード後も残る）／入力中は POST が飛ばず blur 時1回だけ upsert／状態トグル後もメモが消えない

🤖 Generated with [Claude Code](https://claude.com/claude-code)