### PR TITLE
docs: _viewModeStore のキャッシュコメントを実態に合わせて修正

### DIFF
--- a/my-app/app/team_schedules/_viewModeStore.ts
+++ b/my-app/app/team_schedules/_viewModeStore.ts
@@ -37,7 +37,8 @@ export function saveViewMode(mode: ViewMode): void {
   }
 }
 
-// 同一参照で安定させるため、解決済みの値をキャッシュする（undefined = 未読込）
+// getSnapshot のたびに localStorage を読み直さないよう、解決済みの値をキャッシュする（undefined = 未読込）。
+// ViewMode は primitive なので _selectionStore（object 返却で参照安定が必須）と違い参照安定は不要だが、I/O 回避のため同じ形を採る。
 let cache: ViewMode | null | undefined
 const listeners = new Set<() => void>()
 


### PR DESCRIPTION
## 概要

PR #141（スマホ向けカード表示モード）のセルフレビューで見つけたコメントの誤りを修正する follow-up。#141 は squash マージ済みのため、本修正は develop に届いておらず、別PRで取り込む。

## 修正内容

`_viewModeStore.ts` のキャッシュコメントが実態とずれていた。

- 旧: 「同一参照で安定させるため、解決済みの値をキャッシュする」
- 新: localStorage の再読込回避が目的であること、`ViewMode` は primitive なので `_selectionStore`（object 返却で参照安定が必須）と違い参照安定は不要であることを明記。

`_selectionStore.ts` の該当コメント（「同一参照を返さないと無限再レンダリング」）を実コードで裏取り済み。挙動への影響なし（コメントのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)