### PR TITLE
feat: 自チームが活動可能な日に「活動可」バッジを表示 (#143)

### DIFF
--- a/my-app/app/team_schedules/_components/ScheduleDayCards.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleDayCards.tsx
@@ -53,6 +53,8 @@ export function ScheduleDayCards({ rows, threshold, opponentColumns, memberColum
                 {d.label}
                 <span className="ml-0.5 text-xs font-medium">（{d.weekday}）</span>
               </span>
+              {/* 自チームが活動可能な日は「活動可」を明示（成立=相手も一致 とは別軸。塗りの成立バッジと区別してアウトライン表示） */}
+              {row.ownActive && <span className="rounded border border-emerald-600 px-1 py-px text-[10px] font-bold text-emerald-400">活動可</span>}
               <span className={"ml-auto text-sm font-bold " + (row.okCount >= threshold ? "text-emerald-400" : "text-zinc-500")}>
                 ○{row.okCount}
                 {row.maybeCount > 0 && <span className="ml-0.5 text-xs font-normal text-amber-500">+{row.maybeCount}△</span>}

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -62,13 +62,18 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
       header: "日付",
       size: SIZE.date,
       cell: ({ row }) => {
-        const d = row.original.date
+        const r = row.original
+        const d = r.date
         const wkColor = d.isSunday ? "text-rose-400" : d.isSaturday ? "text-sky-400" : "text-zinc-200"
         return (
-          <span className={"text-xs font-medium " + wkColor}>
-            {d.label}
-            <span className="ml-0.5 text-[11px]">（{d.weekday}）</span>
-          </span>
+          <div className="flex flex-col items-start gap-0.5">
+            <span className={"text-xs font-medium " + wkColor}>
+              {d.label}
+              <span className="ml-0.5 text-[11px]">（{d.weekday}）</span>
+            </span>
+            {/* 自チームが活動可能な日は「活動可」を明示（成立=相手も一致 とは別軸。塗りの成立バッジと区別してアウトライン表示） */}
+            {r.ownActive && <span className="rounded border border-emerald-600 px-1 py-px text-[10px] font-bold text-emerald-400">活動可</span>}
+          </div>
         )
       },
     }


### PR DESCRIPTION
## 概要

Issue #143（チーム単位モードで○にしても「活動可」と分かりにくい）への対応。

日付セル（グリッド/カード両方）に、自チームが活動可能な日へアウトラインの「活動可」バッジを表示する。塗りの「成立」バッジ（=相手も一致）とは別軸の表示として区別している。

## 変更点（develop との差分は2ファイル）

- [ScheduleGrid.tsx](my-app/app/team_schedules/_components/ScheduleGrid.tsx): 日付列を flex-col 化し `ownActive` 時にバッジ表示
- [ScheduleDayCards.tsx](my-app/app/team_schedules/_components/ScheduleDayCards.tsx): カードヘッダーに同バッジを表示

## 確認

- `npx tsc --noEmit` / `npm run lint` クリーン
- team / member 両モードで「活動可」表示されることを意図（レビュー済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)