### PR TITLE
refactor: team_schedules のレイアウト枠分離と LolHeader の rightSlot 汎用化

### DIFF
--- a/my-app/app/lol/_components/LolHeader.tsx
+++ b/my-app/app/lol/_components/LolHeader.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, type ReactNode } from "react"
 import Link from "next/link"
 import { useOverlay } from "@/app/_client/lib/modal/ModalContext"
 import { DiscordWebhookOverlay } from "@/app/lol/opgg-multi-link/_components/DiscordWebhookOverlay"
@@ -14,16 +14,15 @@ const NAV_LINKS = [
 ]
 
 /**
- * ログイン中ユーザー名を右側に表示したいページから渡す。
- * - userName があればその名前を表示
- * - userName が無く onLogin が渡されていれば「ログイン」ボタンを表示
+ * ヘッダー右端に表示する任意の要素。
+ * ログイン表示などページ固有の要素は、ここに渡して組み込む（LolHeader 自身はログイン等の概念を持たない）。
+ * 未指定なら右端は空（lol 配下の各ページは渡さない）。
  */
 type LolHeaderProps = {
-  userName?: string | null
-  onLogin?: () => void
+  rightSlot?: ReactNode
 }
 
-export default function LolHeader({ userName, onLogin }: LolHeaderProps = {}) {
+export default function LolHeader({ rightSlot }: LolHeaderProps = {}) {
   const [isOpen, setIsOpen] = useState(false)
   const { open } = useOverlay()
 
@@ -88,23 +87,8 @@ export default function LolHeader({ userName, onLogin }: LolHeaderProps = {}) {
             LoL ツール
           </Link>
 
-          {/* 右端: ログイン中はユーザー名、未ログイン時はログインボタン */}
-          {userName ? (
-            <span className="ml-auto flex items-center gap-1.5 truncate text-sm text-zinc-300" title={userName}>
-              <span aria-hidden="true">👤</span>
-              <span className="truncate">{userName}</span>
-            </span>
-          ) : (
-            onLogin && (
-              <button
-                type="button"
-                onClick={onLogin}
-                className="ml-auto rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500"
-              >
-                ログイン
-              </button>
-            )
-          )}
+          {/* 右端: ページ固有の要素（ログイン表示など）を渡された場合のみ表示する */}
+          {rightSlot && <div className="ml-auto flex items-center">{rightSlot}</div>}
         </div>
       </header>
     </>

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -783,12 +783,25 @@ export function TeamSchedulesPage() {
   // 自分が1つでもチームに所属しているか（teams 一覧の isMember 由来）。md以下で「チームを作成」ボタンを隠す判定に使う。
   const belongsToAnyTeam = useMemo(() => teams.some((t) => t.isMember), [teams])
 
-  // md以下（lg未満）はヘッダー＋body を画面内に収め、カレンダー（グリッド）だけスクロールさせる。lg以上は通常のページスクロール。
+  // ヘッダー右端のログイン表示（team_schedules 固有）。LolHeader には rightSlot で渡す。
+  // 初期ロード中（session 未確定）はログインボタンを出さない（loading 中は null）。
+  // 確定後はログイン済みならユーザー名、未ログインならログインボタンを表示する。
+  const loginSlot = session?.displayName ? (
+    <span className="flex items-center gap-1.5 truncate text-sm text-zinc-300" title={session.displayName}>
+      <span aria-hidden="true">👤</span>
+      <span className="truncate">{session.displayName}</span>
+    </span>
+  ) : loading ? null : (
+    <button type="button" onClick={openLogin} className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-500">
+      ログイン
+    </button>
+  )
+
+  // ビューポート枠（h-dvh の flex 縦積み等）は layout.tsx に移設済み。ここはその中身（ヘッダー＋body）を返す。
   return (
-    <div className="flex h-dvh flex-col overflow-hidden bg-zinc-950 text-zinc-100 lg:block lg:h-auto lg:min-h-screen lg:overflow-visible">
+    <>
       <div className="shrink-0">
-        {/* 初期ロード中（session 未確定）はログインボタンを出さない。確定後に未ログインなら onLogin が渡りボタン表示、ログイン済みなら userName 表示 */}
-        <LolHeader userName={session?.displayName ?? null} onLogin={loading ? undefined : openLogin} />
+        <LolHeader rightSlot={loginSlot} />
       </div>
       <div className="mx-auto flex min-h-0 w-full max-w-6xl flex-1 flex-col p-2.5 md:p-6 lg:block gap-1.5">
         <div className="flex shrink-0 flex-wrap items-start justify-between md:gap-2">
@@ -1002,6 +1015,6 @@ export function TeamSchedulesPage() {
       )}
 
       <DbHealthButton />
-    </div>
+    </>
   )
 }

--- a/my-app/app/team_schedules/layout.tsx
+++ b/my-app/app/team_schedules/layout.tsx
@@ -1,0 +1,14 @@
+/**
+ * /team_schedules のビューポート枠。
+ * md以下（lg未満）はヘッダー＋body を画面内に収め、カレンダー（グリッド）だけスクロールさせる。
+ * lg以上は通常のページスクロール。
+ * ヘッダー（LolHeader）の描画とログイン状態は page 側に残す（ログイン表示は team_schedules 固有のため、
+ * 汎用の LolHeader には rightSlot で下から渡す。App Router では layout から page の状態を参照できないため）。
+ */
+export default function TeamSchedulesLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-dvh flex-col overflow-hidden bg-zinc-950 text-zinc-100 lg:block lg:h-auto lg:min-h-screen lg:overflow-visible">
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要

`/team_schedules` のヘッダー周りを整理。ビューポート枠（CSS）を layout に切り出し、共有ヘッダー `LolHeader` からログイン特化を排して汎用スロット化した。機能・見た目に変更はなし（リファクタ）。

## 変更

- **ビューポート枠を layout へ**: `h-dvh flex flex-col overflow-hidden … lg:block` の枠を `TeamSchedulesPage` から新規 `app/team_schedules/layout.tsx` に移設。
- **LolHeader を汎用化**: ログイン特化 props `userName`/`onLogin` を撤去し、汎用の `rightSlot?: ReactNode` に統一。LolHeader 自身は「ログイン」概念を持たず、右端に渡された任意要素を表示するだけに。
- **ログイン表示は page 側で組み立て**: ユーザー名 / ログインボタンを `loginSlot` として `TeamSchedulesPage` で生成し `<LolHeader rightSlot={loginSlot} />` に渡す。旧 props の3分岐（名前 / 初期ロード中は非表示 / ログインボタン）を同義で維持。
- lol 配下の各ページは `<LolHeader />`（`rightSlot` 未指定）で従来どおり右端は空。

## 設計判断（今回の議論の結論）

- **ヘッダーの「本質」はナビ外殻（ページタイトル＋ハンバーガー）で、これは既に `LolHeader` として共通化済み**。今回さらにログイン表示を切り離し、共有コンポーネントから team_schedules 固有の概念を排した。
- **Context は使わない**方針。App Router では layout が `LolHeader` を描くと `{children}`（page）より上にあるため、page の `session`/`openLogin` を上方向に渡せない。それを可能にするのが Context/portal だが、provider 化は大げさなので採らない。
- 結果として **ヘッダーの描画は page に残し、`rightSlot` を prop で下から渡す**形にした（layout に上げるのは再利用可能な CSS 枠のみ）。lol と完全に同じ「ヘッダーを layout で描く」形にできない理由は、team_schedules のヘッダーがログイン状態に依存する（=ステートフル）ため。
- **未決（今回スコープ外）**: 「team_schedules を LoL ツールの1機能として `/lol` 配下に寄せるか、別プロダクトとして分けるか」という IA は保留。本変更はどちらに倒しても無駄にならない土台。

## 確認

- `npm run lint` / `npx tsc --noEmit` クリーン
- 挙動変更なし（ヘッダー表示・ログイン導線・md以下のグリッドのみスクロールは従来どおり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)