### PR TITLE
perf: team_schedules 参加チームの予定をページ表示時に先読み (#165)

### DIFF
--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -85,6 +85,8 @@ export function TeamSchedulesPage() {
   // 選択の整合（後段の reconcile 効果で参照）。magic-link ログイン確立後の再取得で
   // false に戻し、正しい isMember を反映した teams でもう一度だけ走らせる。
   const reconciledRef = useRef(false)
+  // 同一チームの取得が複数 effect 発火で二重に走らないようにする（#165: 先読みと選択取得の重複防止）
+  const fetchingRef = useRef<Set<string>>(new Set())
 
   // token / join を URL から消す際、対象チーム選択用の team= だけは残して掃除する。
   // 招待リンク（?join=...&team=...）は join を消費しても team を後段の効果で読み取る必要があるため、
@@ -223,18 +225,25 @@ export function TeamSchedulesPage() {
     router.replace(qs ? `/team_schedules?${qs}` : "/team_schedules")
   }, [teamParam, loading, teams, setOwnTeamId, router])
 
-  // 選択中チームの予定を取得
+  // 予定取得: 選択中チーム + 参加チーム全てを先読みする（#165）。
+  // 自チームに選べるのは参加チームだけなので、開いた時点で全参加チームを取得しておけば
+  // 自チーム切替時のスピナーを無くせる。相手チームは選択時に取得し、以降はキャッシュを使う。
   useEffect(() => {
-    const ids = [ownTeamId, ...opponentTeamIds].filter((id): id is string => !!id)
+    if (loading) return
     const from = dayKeys[0]
     const to = dayKeys[dayKeys.length - 1]
+    const memberIds = teams.filter((t) => t.isMember).map((t) => t.teamId)
+    const selectedIds = [ownTeamId, ...opponentTeamIds].filter((id): id is string => !!id)
+    const ids = Array.from(new Set([...selectedIds, ...memberIds]))
     ids.forEach((id) => {
-      if (schedulesByTeam[id]) return
+      if (schedulesByTeam[id] || fetchingRef.current.has(id)) return
+      fetchingRef.current.add(id)
       void fetchTeamSchedule(id, from, to)
         .then((team) => setSchedulesByTeam((prev) => ({ ...prev, [id]: team })))
         .catch(() => {})
+        .finally(() => fetchingRef.current.delete(id))
     })
-  }, [ownTeamId, opponentTeamIds, dayKeys, schedulesByTeam])
+  }, [loading, teams, ownTeamId, opponentTeamIds, dayKeys, schedulesByTeam])
 
   // ローカルの予定を更新（楽観的更新）
   const applyLocalEdit = useCallback((teamId: string, userId: string, day: string, status: CellStatus, note: string) => {

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -228,8 +228,11 @@ export function TeamSchedulesPage() {
   // 予定取得: 選択中チーム + 参加チーム全てを先読みする（#165）。
   // 自チームに選べるのは参加チームだけなので、開いた時点で全参加チームを取得しておけば
   // 自チーム切替時のスピナーを無くせる。相手チームは選択時に取得し、以降はキャッシュを使う。
+  // loading でガードしないのは意図的: 初期ロード中（teams が空）は memberIds が空になり ids=選択中チームだけになる。
+  // localStorage 復元済みの選択中チームの予定を初期ロードと並行で取得し、view を loading 完了前に出すため
+  // （下部カレンダーの「loading を待たず view 準備でき次第表示」コメント参照）。loading 完了で teams が入ると
+  // deps 経由で再実行され、参加チーム全件を先読みする。
   useEffect(() => {
-    if (loading) return
     const from = dayKeys[0]
     const to = dayKeys[dayKeys.length - 1]
     const memberIds = teams.filter((t) => t.isMember).map((t) => t.teamId)
@@ -243,7 +246,7 @@ export function TeamSchedulesPage() {
         .catch(() => {})
         .finally(() => fetchingRef.current.delete(id))
     })
-  }, [loading, teams, ownTeamId, opponentTeamIds, dayKeys, schedulesByTeam])
+  }, [teams, ownTeamId, opponentTeamIds, dayKeys, schedulesByTeam])
 
   // ローカルの予定を更新（楽観的更新）
   const applyLocalEdit = useCallback((teamId: string, userId: string, day: string, status: CellStatus, note: string) => {


### PR DESCRIPTION
## 概要

`/team_schedules` で自チーム/対戦相手を切り替えるたびにスピナーが出ていた問題を改善。
自チームに選べるのは**参加チームだけ**なので、ページ表示時に全参加チームの予定を先読みし、
自チーム切替時の「読み込み中…」を無くした。

## 変更内容

- 予定取得 effect を「選択中チーム + 参加チーム全て」を取得する形に統合（先読み）
- 先読みと選択取得が同じチームを二重 fetch しないよう in-flight ガード `fetchingRef` を追加
- 対戦相手の選択切替で再取得しない挙動は元から `schedulesByTeam[id]` キャッシュで実現済みのため据え置き

## 確認

- `npm run lint` / `npx tsc --noEmit` パス

## close 予定

- close #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)