### PR TITLE
chore: team_schedules ローカル開発ツール（env 統一・seed 拡張・Makefile）

### DIFF
--- a/.claude/rules-on-demand/database.md
+++ b/.claude/rules-on-demand/database.md
@@ -50,7 +50,9 @@ npm run db:studio     # GUIで中身を確認
 npm run db:push       # 開発時に生成をスキップして直接スキーマを反映（任意）
 ```
 
-- `drizzle-kit` は `dotenv/config` で **`.env`** を読む（`.env.local` ではない）。
+- `drizzle-kit` / seed・infra スクリプトは `my-app/scripts/loadEnv.mjs` を読み込み、**`next dev` と同じ優先順位**で env を解決する（`.env.local` > `.env`。シェルの export / `VAR=x` CLI 指定が最優先）。
+  - これにより「dev は `.env.local`・migrate/seed は `.env`」と接続先がズレる事故を防ぐ。
+  - シェルに `export DATABASE_URL=...` 等が残っていると `.env.local` より優先されて事故るため、ルートの `Makefile` の各ターゲットは `env -u DATABASE_URL -u REDIS_URL` で接続文字列を剥がしてから実行する。
 - CHECK制約は Drizzle のバージョンによって生成SQLに出ないことがある。`db:generate` 後、
   出力された SQL に `CONSTRAINT ... CHECK` が入っているか目視確認する。
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+# team_schedules（スクリム調整機能）のローカル動作確認用 Makefile
+#
+# docker-compose.yml はこのディレクトリ、npm スクリプトは my-app/ で動く。
+# 各ターゲットは内部で `cd my-app` を行うのでリポジトリルートで実行すればよい。
+#
+# よく使う流れ:
+#   make verify   # DB/Redis 起動 → migrate → seed → ログインURL発行（初回はこれ1発）
+#   make dev      # 別ターミナルで dev サーバー起動
+#   出力された magic-link URL をブラウザで開いてログイン
+#
+# トークンが切れたら `make login` で再発行（seed はやり直さない）。
+
+APP_DIR := my-app
+COMPOSE := docker compose
+
+# シェルに残った export（例: `export DATABASE_URL=...`）は Next も dotenv も上書きしないため、
+# .env.local より優先されてしまい「dev だけ別 DB を掴む」事故が起きる。
+# ローカルの make では接続文字列をシェルから剥がし、必ず .env/.env.local を使わせる。
+LOCAL_ENV := env -u DATABASE_URL -u REDIS_URL
+
+.DEFAULT_GOAL := help
+
+.PHONY: help db-up db-down logs migrate seed login creator-login dev run db-run studio psql verify reset
+
+help: ## このヘルプを表示
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+
+db-up: ## DB + Redis を起動（healthy になるまで待つ）
+	$(COMPOSE) up -d --wait db redis
+
+db-down: ## DB + Redis を停止（データは pgdata/redis_data に残る）
+	$(COMPOSE) stop db redis
+
+logs: ## DB + Redis のログを追う
+	$(COMPOSE) logs -f db redis
+
+migrate: ## マイグレーションを適用（.env.local の DATABASE_URL 先）
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run db:migrate
+
+seed: ## テストチーム・メンバー・予定を投入し、ログインURLを発行（MEMBERS=10 で一般メンバーを追加生成）
+	cd $(APP_DIR) && $(LOCAL_ENV) EXTRA_MEMBERS=$(MEMBERS) npm run seed:team-schedules
+
+login: ## seed せず magic-link ログインURLだけ再発行（トークン失効時。MEMBERS は seed 時と同じ値を指定）
+	cd $(APP_DIR) && $(LOCAL_ENV) EXTRA_MEMBERS=$(MEMBERS) node scripts/team-schedules/seed-team-schedules.mjs --login-only
+
+creator-login: ## TEAM_SCHEDULE_CREATOR_DISCORD_IDS のユーザー分のログインURLを発行
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run creator-login:team-schedules
+
+dev: ## dev サーバーを起動（http://localhost:3000）
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run dev
+
+run: db-up ## Redis + Postgres を起動してから dev サーバーを起動（これ1発で動作確認）
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run dev
+
+db-run: db-up ## Redis + Postgres だけ起動（dev サーバーは起動しない）
+
+studio: ## Drizzle Studio で DB の中身を確認
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run db:studio
+
+psql: ## ローカル DB に psql で接続
+	docker exec -it discord-janken-db psql -U postgres -d team_schedules
+
+verify: db-up migrate seed ## 動作確認の初期セットアップ一括（db-up → migrate → seed）
+	@echo ""
+	@echo "✅ セットアップ完了。別ターミナルで 'make dev' を実行し、上の magic-link URL を開いてください。"
+
+reset: ## DB/Redis を破棄して作り直す（pgdata/redis_data ごと削除・破壊的）
+	$(COMPOSE) down -v
+	$(MAKE) verify

--- a/my-app/drizzle.config.ts
+++ b/my-app/drizzle.config.ts
@@ -1,4 +1,4 @@
-import "dotenv/config"
+import "./scripts/loadEnv.mjs"
 import { defineConfig } from "drizzle-kit"
 
 // マイグレーション生成・適用の設定。

--- a/my-app/scripts/infra/diagnose-migrations.mjs
+++ b/my-app/scripts/infra/diagnose-migrations.mjs
@@ -9,9 +9,9 @@
 // drizzle-kit migrate がエラーを握り潰すため、ここでは __drizzle_migrations の
 // 適用記録と、実際に存在するテーブル/カラム/制約を SELECT で読み出して突き合わせる。
 
-// my-app/.env を読み込む（drizzle.config.ts と同じ挙動）。
-// 既に環境変数で DATABASE_URL が渡っていればそちらが優先される（dotenv は上書きしない）。
-import "dotenv/config"
+// my-app の .env.local / .env を next dev と同じ優先順位で読み込む（drizzle.config.ts と同じ挙動）。
+// 既に環境変数で DATABASE_URL が渡っていればそちらが優先される（ファイルでは上書きしない）。
+import "../loadEnv.mjs"
 import { Pool } from "pg"
 
 const url = process.env.DATABASE_URL

--- a/my-app/scripts/infra/reset-db.mjs
+++ b/my-app/scripts/infra/reset-db.mjs
@@ -22,8 +22,9 @@
 //    （実行ブランチに応じた environment の DATABASE_URL secret で migrate が走る）。
 // 4. run が緑になれば __drizzle_migrations と実スキーマが一致した状態になる。
 
-// my-app/.env を読み込む。環境変数で DATABASE_URL が渡っていればそちらが優先される。
-import "dotenv/config"
+// my-app の .env.local / .env を next dev と同じ優先順位で読み込む。
+// 環境変数で DATABASE_URL が渡っていればそちらが優先される（ファイルでは上書きしない）。
+import "../loadEnv.mjs"
 import { Pool } from "pg"
 
 const url = process.env.DATABASE_URL

--- a/my-app/scripts/loadEnv.mjs
+++ b/my-app/scripts/loadEnv.mjs
@@ -1,0 +1,23 @@
+// ローカル開発ツール（drizzle-kit / seed スクリプト / infra スクリプト 等）用の env ローダー。
+//
+// 素の `import "dotenv/config"` は `.env` しか読まないため、`next dev` が読む
+// `.env.local` 等に置いた値を拾えず、「seed/migrate は .env、dev は .env.local」と
+// 接続先がズレる事故が起きる。ここでは next dev と同じ優先順位に揃える。
+//
+// 優先順位（高い方が勝つ）:
+//   process.env（シェルの export / `VAR=x node ...` の CLI 指定）
+//     > .env.development.local > .env.local > .env.development > .env
+//
+// dotenv はデフォルト（override なし）で「既に設定済みのキーは上書きしない」ため、
+// 高い優先度のファイルから順に読み込めば、先に設定された値が残る。
+// これにより (1) シェルで渡した値が常に勝つ＝スクリプトの `VAR=x node ...` 上書きを維持しつつ、
+// (2) ファイル間では next dev と同じく .env.local が .env に勝つ、を両立する。
+//
+// 注意: dotenv のパス解決は process.cwd() 基準（モジュール位置ではない）。
+// これらのツールは my-app 直下で実行する前提なので、相対パスはそこに解決される。
+import { config } from "dotenv"
+
+config({ path: ".env.development.local" })
+config({ path: ".env.local" })
+config({ path: ".env.development" })
+config({ path: ".env" })

--- a/my-app/scripts/team-schedules/creator-login-links.mjs
+++ b/my-app/scripts/team-schedules/creator-login-links.mjs
@@ -13,15 +13,15 @@
 //   node scripts/team-schedules/creator-login-links.mjs                 # member作成 + ログインURL発行
 //   node scripts/team-schedules/creator-login-links.mjs --login-only    # 作成せず、既存ユーザーのログインURLだけ再発行
 //
-// 接続先は my-app/.env の DATABASE_URL / REDIS_URL / APP_URL を使う
-// （コマンド先頭で `APP_URL=http://localhost:3000 node ...` のように上書きも可能）。
+// 接続先は my-app の .env.local / .env の DATABASE_URL / REDIS_URL / APP_URL を使う
+// （next dev と同じ優先順位。コマンド先頭で `APP_URL=http://localhost:3000 node ...` のように上書きも可能）。
 // 注意: magic-link は「dev サーバーが読む Redis」に書く必要があるため、
 //       REDIS_URL は起動中の next dev と同じものを指すこと。
 //
 // 安全弁: DATABASE_URL が neon.tech（本番/プレビュー想定）の場合は、
 //         誤爆防止のため CONFIRM_SEED=yes を付けないと実行できない。
 
-import "dotenv/config"
+import "../loadEnv.mjs"
 import { randomBytes } from "crypto"
 import { Pool } from "pg"
 import { createClient } from "redis"

--- a/my-app/scripts/team-schedules/seed-team-schedules.mjs
+++ b/my-app/scripts/team-schedules/seed-team-schedules.mjs
@@ -1,7 +1,8 @@
 // スクリム調整機能（/team_schedules）のローカル動作確認用シードスクリプト。
 //
 // Discord 経由でしかチーム/ユーザーを作れないため、ローカルDBに
-// 「管理者(master)1人 + 一般メンバー2人 + チーム1つ + 数日ぶんの予定」を投入し、
+// 「チーム1つ + 管理者(master)1人 + 一般メンバーA1人（ここまでチーム所属）
+//   + チーム未参加のB1人（ログインのみ・非メンバー体験のテスト用） + 数日ぶんの予定」を投入し、
 // 各ユーザーの magic-link ログインURL（Redis のワンタイムトークン）を発行する。
 // 発行したURLをブラウザで開けば、Discord を介さずにそのユーザーとしてログインできる。
 //
@@ -9,16 +10,19 @@
 //   cd my-app
 //   node scripts/team-schedules/seed-team-schedules.mjs                 # シード + 全ユーザーのログインURL発行
 //   node scripts/team-schedules/seed-team-schedules.mjs --login-only    # シードせず、ログインURLだけ再発行（トークン失効時）
+//   EXTRA_MEMBERS=10 node scripts/team-schedules/seed-team-schedules.mjs # 固定3人に加え、一般メンバーを10人ぶん自動生成して投入
+//   （Makefile からは `make seed MEMBERS=10` で同じことができる）
+//   ※ EXTRA_MEMBERS は --login-only でも同じ数を指定すること（生成メンバーぶんのログインURLを再発行するため）
 //
-// 接続先は my-app/.env の DATABASE_URL / REDIS_URL / APP_URL を使う
-// （コマンド先頭で `APP_URL=http://localhost:3000 node ...` のように上書きも可能）。
+// 接続先は my-app の .env.local / .env の DATABASE_URL / REDIS_URL / APP_URL を使う
+// （next dev と同じ優先順位。コマンド先頭で `APP_URL=http://localhost:3000 node ...` のように上書きも可能）。
 // 注意: magic-link は「dev サーバーが読む Redis」に書く必要があるため、
 //       REDIS_URL は起動中の next dev と同じものを指すこと。
 //
 // 安全弁: DATABASE_URL が neon.tech（本番/プレビュー想定）の場合は、
 //         誤爆防止のため CONFIRM_SEED=yes を付けないと実行できない。
 
-import "dotenv/config"
+import "../loadEnv.mjs"
 import { randomBytes } from "crypto"
 import { Pool } from "pg"
 import { createClient } from "redis"
@@ -29,12 +33,28 @@ const MAGIC_LINK_TTL = Number(process.env.MAGIC_LINK_TTL_SECONDS ?? 3600) // dev
 
 const TEAM = { teamId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", name: "テストチーム（管理用）", description: "ローカル動作確認用のシードチーム", requiredCount: 3, managementMode: "members" }
 
-// teamRole: master = 管理者（チームに1人）, member = 一般
-const SEED_USERS = [
+// teamRole: master = 管理者（チームに1人）, member = 一般メンバー, null = チーム未参加
+// （null はユーザー/ログインだけ作り、チームには入れない。非メンバーから見た表示のテスト用）
+const BASE_USERS = [
   { userId: "11111111-1111-4111-8111-111111111111", discordUserId: "900000000000000001", displayName: "テスト管理者", teamRole: "master" },
   { userId: "22222222-2222-4222-8222-222222222222", discordUserId: "900000000000000002", displayName: "テストメンバーA", teamRole: "member" },
-  { userId: "33333333-3333-4333-8333-333333333333", discordUserId: "900000000000000003", displayName: "テストメンバーB", teamRole: "member" },
+  { userId: "33333333-3333-4333-8333-333333333333", discordUserId: "900000000000000003", displayName: "テストメンバーB", teamRole: null },
 ]
+
+// EXTRA_MEMBERS=N で、固定3人に加えて一般メンバー(member)を N 人ぶん自動生成する。
+// 冪等にするため、index から決め打ちの UUID / Discord ID を組み立てる（再実行で同じ人に上書きされる）。
+const extraMembers = Math.max(0, Math.floor(Number(process.env.EXTRA_MEMBERS ?? 0)) || 0)
+const GENERATED_USERS = Array.from({ length: extraMembers }, (_, idx) => {
+  const n = idx + 1
+  return {
+    userId: `cccccccc-cccc-4ccc-8ccc-${String(n).padStart(12, "0")}`,
+    discordUserId: `9000001${String(n).padStart(11, "0")}`, // 7 + 11 = 18桁（Discord snowflake と同じ桁数）
+    displayName: `自動メンバー${n}`,
+    teamRole: "member",
+  }
+})
+
+const SEED_USERS = [...BASE_USERS, ...GENERATED_USERS]
 
 const loginOnly = process.argv.includes("--login-only")
 
@@ -103,8 +123,14 @@ async function seed(pool) {
     [TEAM.teamId, TEAM.name, TEAM.description, TEAM.requiredCount, TEAM.managementMode],
   )
 
-  // team_members（ロールは常に整合させる）
+  // team_members: teamRole があるユーザーだけ登録（ロールは常に整合させる）。
+  // teamRole=null（未参加）は、過去の seed で参加済みだった場合に備えて所属と予定を掃除する。
   for (const u of SEED_USERS) {
+    if (u.teamRole === null) {
+      await pool.query(`DELETE FROM team_members WHERE team_id = $1 AND user_id = $2`, [TEAM.teamId, u.userId])
+      await pool.query(`DELETE FROM schedules WHERE team_id = $1 AND user_id = $2`, [TEAM.teamId, u.userId])
+      continue
+    }
     await pool.query(
       `INSERT INTO team_members (team_id, user_id, team_role) VALUES ($1, $2, $3)
        ON CONFLICT (team_id, user_id) DO UPDATE SET team_role = EXCLUDED.team_role`,
@@ -112,11 +138,13 @@ async function seed(pool) {
     )
   }
 
-  // schedules（members モードのグリッドが空にならないよう、今日から数日ぶんを投入）
+  // schedules（members モードのグリッドが空にならないよう、今日から数日ぶんを投入）。
+  // チーム所属メンバー（teamRole != null）のぶんだけ入れる。
+  const members = SEED_USERS.filter((u) => u.teamRole !== null)
   const statuses = ["ok", "maybe", "ng"]
   let count = 0
-  for (let i = 0; i < SEED_USERS.length; i++) {
-    const u = SEED_USERS[i]
+  for (let i = 0; i < members.length; i++) {
+    const u = members[i]
     for (let d = 0; d < 4; d++) {
       // ユーザー/日でずらして ok/maybe/ng を散らす
       const status = statuses[(i + d) % statuses.length]
@@ -130,7 +158,8 @@ async function seed(pool) {
     }
   }
 
-  console.log(`シード完了: team「${TEAM.name}」/ users ${SEED_USERS.length}人 / schedules ${count}行`)
+  const nonMembers = SEED_USERS.length - members.length
+  console.log(`シード完了: team「${TEAM.name}」/ メンバー ${members.length}人 + 未参加 ${nonMembers}人 / schedules ${count}行`)
 }
 
 // --- magic-link 発行（Redis書き込み） ---------------------------------------
@@ -142,7 +171,7 @@ async function issueLoginLinks(redis) {
     // login.ts と同じ形: key=ts:magic:{token}, value={discordUserId, username}
     const payload = JSON.stringify({ discordUserId: u.discordUserId, username: u.displayName })
     await redis.setEx(`ts:magic:${token}`, MAGIC_LINK_TTL, payload)
-    const roleLabel = u.teamRole === "master" ? "管理者(master)" : "メンバー"
+    const roleLabel = u.teamRole === "master" ? "管理者(master)" : u.teamRole === "member" ? "メンバー" : "未参加（チーム未所属）"
     lines.push(`  [${roleLabel}] ${u.displayName}\n    ${appUrl}/team_schedules?token=${token}`)
   }
   const expiryMinutes = Math.round(MAGIC_LINK_TTL / 60)


### PR DESCRIPTION
## 概要

`/team_schedules` のローカル動作確認まわりの開発ツールを整備する。UI 変更は含まない（別ブランチ）。

## 変更内容

- **env 読み込みの統一**: 共有ローダー `my-app/scripts/loadEnv.mjs` を追加し、drizzle-kit / seed / infra スクリプトを差し替え。`next dev` と同じ優先順位（`process.env` > `.env.development.local` > `.env.local` > `.env.development` > `.env`）で解決し、「seed/migrate は .env・dev は .env.local」で接続先がズレる事故を防ぐ。シェル/CLI（`VAR=x`）の上書きは維持。`database.md` を実挙動に合わせて更新。
- **seed 拡張** (`seed-team-schedules.mjs`): テストメンバーB を「チーム未参加」にして非メンバー表示を確認可能に（冪等）。`EXTRA_MEMBERS=N` で一般メンバーを自動生成。
- **Makefile 追加**: db/redis 起動・migrate・seed・dev 起動などをまとめる。シェルに残った `DATABASE_URL`/`REDIS_URL` の export は `env -u` で剥がし、必ず `.env.local` を使わせる。

## 確認

- `npm run lint` / `npx tsc --noEmit` パス
- `make seed` / `make migrate` がローカル docker（localhost）に届くことを確認（stray export があっても `env -u` で剥がれる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)