### PR TITLE
release: team_schedules 表の表示調整・ローカル開発ツール整備

### DIFF
--- a/.claude/rules-on-demand/database.md
+++ b/.claude/rules-on-demand/database.md
@@ -50,7 +50,9 @@ npm run db:studio     # GUIで中身を確認
 npm run db:push       # 開発時に生成をスキップして直接スキーマを反映（任意）
 ```
 
-- `drizzle-kit` は `dotenv/config` で **`.env`** を読む（`.env.local` ではない）。
+- `drizzle-kit` / seed・infra スクリプトは `my-app/scripts/loadEnv.mjs` を読み込み、**`next dev` と同じ優先順位**で env を解決する（`.env.local` > `.env`。シェルの export / `VAR=x` CLI 指定が最優先）。
+  - これにより「dev は `.env.local`・migrate/seed は `.env`」と接続先がズレる事故を防ぐ。
+  - シェルに `export DATABASE_URL=...` 等が残っていると `.env.local` より優先されて事故るため、ルートの `Makefile` の各ターゲットは `env -u DATABASE_URL -u REDIS_URL` で接続文字列を剥がしてから実行する。
 - CHECK制約は Drizzle のバージョンによって生成SQLに出ないことがある。`db:generate` 後、
   出力された SQL に `CONSTRAINT ... CHECK` が入っているか目視確認する。
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+# team_schedules（スクリム調整機能）のローカル動作確認用 Makefile
+#
+# docker-compose.yml はこのディレクトリ、npm スクリプトは my-app/ で動く。
+# 各ターゲットは内部で `cd my-app` を行うのでリポジトリルートで実行すればよい。
+#
+# よく使う流れ:
+#   make verify   # DB/Redis 起動 → migrate → seed → ログインURL発行（初回はこれ1発）
+#   make dev      # 別ターミナルで dev サーバー起動
+#   出力された magic-link URL をブラウザで開いてログイン
+#
+# トークンが切れたら `make login` で再発行（seed はやり直さない）。
+
+APP_DIR := my-app
+COMPOSE := docker compose
+
+# シェルに残った export（例: `export DATABASE_URL=...`）は Next も dotenv も上書きしないため、
+# .env.local より優先されてしまい「dev だけ別 DB を掴む」事故が起きる。
+# ローカルの make では接続文字列をシェルから剥がし、必ず .env/.env.local を使わせる。
+LOCAL_ENV := env -u DATABASE_URL -u REDIS_URL
+
+.DEFAULT_GOAL := help
+
+.PHONY: help db-up db-down logs migrate seed login creator-login dev run db-run studio psql verify reset
+
+help: ## このヘルプを表示
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+
+db-up: ## DB + Redis を起動（healthy になるまで待つ）
+	$(COMPOSE) up -d --wait db redis
+
+db-down: ## DB + Redis を停止（データは pgdata/redis_data に残る）
+	$(COMPOSE) stop db redis
+
+logs: ## DB + Redis のログを追う
+	$(COMPOSE) logs -f db redis
+
+migrate: ## マイグレーションを適用（.env.local の DATABASE_URL 先）
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run db:migrate
+
+seed: ## テストチーム・メンバー・予定を投入し、ログインURLを発行（MEMBERS=10 で一般メンバーを追加生成）
+	cd $(APP_DIR) && $(LOCAL_ENV) EXTRA_MEMBERS=$(MEMBERS) npm run seed:team-schedules
+
+login: ## seed せず magic-link ログインURLだけ再発行（トークン失効時。MEMBERS は seed 時と同じ値を指定）
+	cd $(APP_DIR) && $(LOCAL_ENV) EXTRA_MEMBERS=$(MEMBERS) node scripts/team-schedules/seed-team-schedules.mjs --login-only
+
+creator-login: ## TEAM_SCHEDULE_CREATOR_DISCORD_IDS のユーザー分のログインURLを発行
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run creator-login:team-schedules
+
+dev: ## dev サーバーを起動（http://localhost:3000）
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run dev
+
+run: db-up ## Redis + Postgres を起動してから dev サーバーを起動（これ1発で動作確認）
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run dev
+
+db-run: db-up ## Redis + Postgres だけ起動（dev サーバーは起動しない）
+
+studio: ## Drizzle Studio で DB の中身を確認
+	cd $(APP_DIR) && $(LOCAL_ENV) npm run db:studio
+
+psql: ## ローカル DB に psql で接続
+	docker exec -it discord-janken-db psql -U postgres -d team_schedules
+
+verify: db-up migrate seed ## 動作確認の初期セットアップ一括（db-up → migrate → seed）
+	@echo ""
+	@echo "✅ セットアップ完了。別ターミナルで 'make dev' を実行し、上の magic-link URL を開いてください。"
+
+reset: ## DB/Redis を破棄して作り直す（pgdata/redis_data ごと削除・破壊的）
+	$(COMPOSE) down -v
+	$(MAKE) verify

--- a/my-app/app/team_schedules/_components/ScheduleCell.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleCell.tsx
@@ -47,7 +47,9 @@ export function ScheduleCell({ status, note, editable, dim = false, onCycle, onN
         className={
           "mx-auto flex h-7 w-7 items-center justify-center rounded-full text-sm font-bold focus:outline-none focus:ring-2 focus:ring-indigo-400 " +
           style.className +
-          (editable ? " cursor-pointer hover:opacity-80" : " cursor-default") +
+          // 未編集（他人の予定等）は矢印カーソル。globals.css の未レイヤー `button{cursor:pointer}` に
+          // 勝つため important 修飾子（cursor-default!）で上書きする。
+          (editable ? " cursor-pointer hover:opacity-80" : " cursor-default!") +
           (dim ? " opacity-65" : "")
         }
       >

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -224,10 +224,12 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
                   const fadeClass = r.impossible ? "opacity-70" : emphasis?.faded ? "opacity-60" : null
                   // ○数列だけ横padを半分にして（px-1.5→px-[3px]）活動可バッジの幅を確保する
                   const xPad = col.id === "count" ? "px-[3px]" : "px-1.5"
+                  // 日付列はボタン+入力欄を持つ他列より背が低いので、縦中央に揃える（他列は上揃え）
+                  const valign = col.id === "date" ? "align-middle" : "align-top"
                   return (
                     <td
                       key={cell.id}
-                      className={"border-b border-r border-zinc-700 py-1.5 align-top text-center " + xPad + " " + cellBg + teamEditRing}
+                      className={"border-b border-r border-zinc-700 py-1.5 text-center " + valign + " " + xPad + " " + cellBg + teamEditRing}
                       style={{ ...pinnedStyle(col, false), minWidth: col.getSize(), width: pinned ? col.getSize() : undefined }}
                     >
                       {fadeClass ? <div className={fadeClass}>{content}</div> : content}

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -15,6 +15,8 @@ type ScheduleGridProps = {
   threshold: number
   opponentColumns: ScheduleColumn[]
   memberColumns: ScheduleColumn[]
+  /** ○数列ヘッダーの上に表示する自チーム名 */
+  ownTeamName: string
   onCycle: (payload: EditPayload & { current: CellStatus }) => void
   onNoteChange: (payload: EditPayload & { value: string }) => void
   /** チーム単位モード列の状態トグル（userId を持たない） */
@@ -58,7 +60,7 @@ function pinnedStyle(column: Column<GridRow>, isHeader: boolean): React.CSSPrope
   }
 }
 
-export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, onCycle, onNoteChange, onTeamCycle, onTeamNoteChange }: ScheduleGridProps) {
+export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, ownTeamName, onCycle, onNoteChange, onTeamCycle, onTeamNoteChange }: ScheduleGridProps) {
   const columns = useMemo<ColumnDef<GridRow>[]>(() => {
     // 列の種別に応じた編集ハンドラ（表・カード共通の makeCellHandlers に委譲）
     const cellHandlers = (col: ScheduleColumn, day: string, current: CellStatus) => makeCellHandlers(col, day, current, { onCycle, onNoteChange, onTeamCycle, onTeamNoteChange })
@@ -85,7 +87,15 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
 
     const countCol: ColumnDef<GridRow> = {
       id: "count",
-      header: "○数",
+      // ○数の上に自チーム名を表示する。div は列幅と同じ 64px 固定、span は左寄せ・1行・はみ出しは隠す
+      header: () => (
+        <div className="flex flex-col items-center gap-0.5">
+          <div className="mx-auto w-16">
+            <span className="block overflow-hidden whitespace-nowrap text-left text-[10px] font-normal text-zinc-300">{ownTeamName}</span>
+          </div>
+          <span>○数</span>
+        </div>
+      ),
       size: SIZE.count,
       cell: ({ row }) => {
         const r = row.original
@@ -144,7 +154,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
     const ownIsTeamMode = memberColumns[0]?.kind === "team"
     // 日付を一番左に。続けて 相手チーム → ○数（自チーム集計・members モードのみ）→ 各メンバー
     return [dateCol, ...opponentCols, ...(ownIsTeamMode ? [] : [countCol]), ...memberCols]
-  }, [opponentColumns, memberColumns, threshold, onCycle, onNoteChange, onTeamCycle, onTeamNoteChange])
+  }, [opponentColumns, memberColumns, ownTeamName, threshold, onCycle, onNoteChange, onTeamCycle, onTeamNoteChange])
 
   const leftPinned = useMemo(() => {
     const ownIsTeamMode = memberColumns[0]?.kind === "team"

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -26,6 +26,12 @@ type ScheduleGridProps = {
 
 const SIZE = { date: 64, count: 64, opponent: 70, member: 78 }
 
+// 2段ヘッダーの上段（自チーム名）の固定高さ(px)。下段ヘッダーの sticky top に使うため固定値にする。
+const OWN_NAME_H = 16
+// 自チーム名の左インデント(px)。padding/margin だと横スクロールでスペースが消えるため、
+// sticky の left オフセットに織り込んで、スクロールしても余白ごと固定されるようにする（≒ pl-5）。
+const OWN_NAME_INDENT = 20
+
 const HEADER_BASE = "border-b border-r border-zinc-700 md:px-2  md:py-2 text-xs font-semibold"
 
 /**
@@ -75,7 +81,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
         // 祝日は日曜と同じ扱い（赤系）。祝日名はツールチップで補足する
         const wkColor = d.isSunday || d.isHoliday ? "text-rose-400" : d.isSaturday ? "text-sky-400" : "text-zinc-200"
         return (
-          <div className="flex flex-col items-center gap-0.5 pt-1">
+          <div className="flex flex-row items-center gap-0.5 pt-1">
             <span className={"text-xs font-medium " + wkColor} title={d.holidayName ?? undefined}>
               {d.label}
               <span className="ml-0.5 text-[11px]">({d.weekday})</span>
@@ -87,15 +93,8 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
 
     const countCol: ColumnDef<GridRow> = {
       id: "count",
-      // ○数の上に自チーム名を表示する。div は列幅と同じ 64px 固定、span は左寄せ・1行・はみ出しは隠す
-      header: () => (
-        <div className="flex flex-col items-center gap-0.5">
-          <div className="mx-auto w-16">
-            <span className="block overflow-hidden whitespace-nowrap text-left text-[10px] font-normal text-zinc-300">{ownTeamName}</span>
-          </div>
-          <span>○数</span>
-        </div>
-      ),
+      // 自チーム名は countCol 単体ではなく、○数〜各メンバーをまたぐ上段ヘッダーで表示する（thead で組み立て）
+      header: "○数",
       size: SIZE.count,
       cell: ({ row }) => {
         const r = row.original
@@ -154,12 +153,13 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
     const ownIsTeamMode = memberColumns[0]?.kind === "team"
     // 日付を一番左に。続けて 相手チーム → ○数（自チーム集計・members モードのみ）→ 各メンバー
     return [dateCol, ...opponentCols, ...(ownIsTeamMode ? [] : [countCol]), ...memberCols]
-  }, [opponentColumns, memberColumns, ownTeamName, threshold, onCycle, onNoteChange, onTeamCycle, onTeamNoteChange])
+  }, [opponentColumns, memberColumns, threshold, onCycle, onNoteChange, onTeamCycle, onTeamNoteChange])
 
+  // ピン留め（sticky-left）は日付＋相手チームのみ。○数〜各メンバー（自チーム区画）は
+  // 上段の自チーム名ヘッダーと一体でスクロールさせたいので、○数のピン留めはしない。
   const leftPinned = useMemo(() => {
-    const ownIsTeamMode = memberColumns[0]?.kind === "team"
-    return ["date", ...opponentColumns.map((c) => `opp:${c.teamId}`), ...(ownIsTeamMode ? [] : ["count"])]
-  }, [opponentColumns, memberColumns])
+    return ["date", ...opponentColumns.map((c) => `opp:${c.teamId}`)]
+  }, [opponentColumns])
 
   // td の className 算出でセル状態を引くための、テーブル列ID → ScheduleColumn の対応表。
   // opponent/member いずれも ScheduleColumn.id がテーブル列IDと一致する（opp:teamId / own:userId など）。
@@ -179,33 +179,83 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
     state: { columnPinning: { left: leftPinned, right: [] } },
   })
 
+  // 自チーム区画の下段ヘッダー（○数＋各メンバー）。members モードは ○数＋メンバー、team モードはチーム1列。
+  const ownIsTeamMode = memberColumns[0]?.kind === "team"
+  const ownLeaves: { key: string; node: React.ReactNode; bg: string; size: number }[] = [
+    ...(ownIsTeamMode ? [] : [{ key: "count", node: "○数", bg: "bg-zinc-800 text-zinc-300", size: SIZE.count }]),
+    ...memberColumns.map((c) => ({ key: c.id, node: c.label, bg: c.editable ? "bg-indigo-600 text-white" : "bg-zinc-800 text-zinc-300", size: SIZE.member })),
+  ]
+  // 2列以上のときだけ上段にチーム名をまたがせる（1列＝team モードはその列ヘッダーを2段ぶち抜きにする）
+  const ownGrouped = ownLeaves.length >= 2
+  // 自チーム名（上段）をピン留めする左オフセット = 日付＋相手チーム（ピン留め列）の合計幅。
+  // これにより横スクロールしてもチーム名だけは相手列の右に常に残る。
+  const ownSectionLeft = SIZE.date + opponentColumns.length * SIZE.opponent
+
   return (
     <div className="h-full min-w-0 overflow-auto rounded-lg border border-zinc-700 bg-zinc-900 lg:h-auto">
       <table className="border-collapse text-sm">
+        {/*
+          2段ヘッダー。日付・相手チームは rowSpan=2 で2段ぶち抜き（従来どおりピン留め）。
+          自チーム区画（○数＋各メンバー）は上段にチーム名を colSpan で渡し、下段に各列ヘッダーを置く。
+          下段は sticky top を上段の高さ(OWN_NAME_H)に合わせて、縦スクロールでも2段固定する。
+        */}
         <thead>
-          {table.getHeaderGroups().map((hg) => (
-            <tr key={hg.id}>
-              {hg.headers.map((header) => {
-                const col = header.column
-                const pinned = col.getIsPinned() === "left"
-                const isEditableMember = memberColumns.find((c) => c.id === col.id)?.editable
-                const isEditableOpp = opponentColumns.find((c) => `opp:${c.teamId}` === col.id)?.editable
-                const editable = isEditableMember || isEditableOpp
-                const bg = editable ? "bg-indigo-600 text-white" : "bg-zinc-800 text-zinc-300"
-                return (
-                  <th
-                    key={header.id}
-                    className={HEADER_BASE + " text-center " + bg}
-                    // position:sticky + top:0 で縦スクロール時はヘッダーを固定。pinned 列のみ left も付くため横スクロールでも残り、
-                    // メンバー列ヘッダーは left を持たない＝縦は固定だが横スクロールでは一緒に流れる。
-                    style={{ ...pinnedStyle(col, true), position: "sticky", top: 0, minWidth: col.getSize(), width: pinned ? col.getSize() : undefined, zIndex: pinned ? 30 : 20 }}
-                  >
-                    {flexRender(col.columnDef.header, header.getContext())}
-                  </th>
-                )
-              })}
+          <tr>
+            {/* 日付: 2段ぶち抜き・ピン留め */}
+            <th
+              rowSpan={2}
+              className={HEADER_BASE + " text-center align-middle bg-zinc-800 text-zinc-300"}
+              style={{ position: "sticky", left: 0, top: 0, zIndex: 30, minWidth: SIZE.date, width: SIZE.date }}
+            >
+              日付
+            </th>
+            {/* 相手チーム: 2段ぶち抜き・ピン留め・相手セレクタの選択中チップと同色（amber） */}
+            {opponentColumns.map((c, i) => (
+              <th
+                key={`opp:${c.teamId}`}
+                rowSpan={2}
+                className={HEADER_BASE + " text-center align-middle bg-amber-500/15 text-amber-300"}
+                style={{ position: "sticky", left: SIZE.date + i * SIZE.opponent, top: 0, zIndex: 30, minWidth: SIZE.opponent, width: SIZE.opponent }}
+              >
+                {c.label}
+              </th>
+            ))}
+            {/* 自チーム: 上段にチーム名（○数〜各メンバーをまたぐ）。自分の色（indigo）で目立たせ、はみ出しは title で全文表示 */}
+            {ownGrouped ? (
+              <th colSpan={ownLeaves.length} className="border-b border-r border-zinc-700 px-2 text-left bg-indigo-500/15" style={{ position: "sticky", top: 0, zIndex: 20, height: OWN_NAME_H }}>
+                {/*
+                  colSpan セル自体への sticky-left は border-collapse 下で効かないことがあるため、
+                  ラベル（span）を sticky-left で固定する。セルは幅が広く背景は残るので、横スクロールしても
+                  チーム名テキストだけが相手列の右に常に残る。左インデントは padding でなく left に織り込み、
+                  スクロールしても余白ごと固定する。
+                */}
+                <span title={ownTeamName} className="inline-block whitespace-nowrap text-[10px] font-medium leading-none text-indigo-300" style={{ position: "sticky", left: ownSectionLeft + OWN_NAME_INDENT }}>
+                  {ownTeamName}
+                </span>
+              </th>
+            ) : (
+              // 自チームが1列（team モード）なら、その列ヘッダーを2段ぶち抜きで表示する
+              ownLeaves.map((l) => (
+                <th key={l.key} rowSpan={2} className={HEADER_BASE + " text-center align-middle " + l.bg} style={{ position: "sticky", top: 0, zIndex: 20, minWidth: l.size }}>
+                  {l.node}
+                </th>
+              ))
+            )}
+          </tr>
+          {ownGrouped && (
+            <tr>
+              {/* 下段: ○数＋各メンバー。sticky top は上段の高さに合わせる */}
+              {ownLeaves.map((l) => (
+                <th
+                  key={l.key}
+                  className={"border-b border-r border-zinc-700 px-2 py-0.5 text-center text-xs font-semibold " + l.bg}
+                  style={{ position: "sticky", top: OWN_NAME_H, zIndex: 20, minWidth: l.size }}
+                >
+                  {l.node}
+                </th>
+              ))}
             </tr>
-          ))}
+          )}
         </thead>
         <tbody>
           {table.getRowModel().rows.map((row) => {
@@ -219,9 +269,9 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
                   const schedCol = columnById.get(col.id)
                   const isTeamCol = schedCol?.kind === "team"
                   const editableMember = memberColumns.find((c) => c.id === col.id)?.editable
-                  // ピン留め列（日付・○数・相手・成立）は行背景を敷く。自メンバー列は編集中のみハイライト。
-                  // team 列は bg を状態強調に使うため indigo bg は敷かない（編集可は下の ring で表現）
-                  let cellBg = pinned ? bg : editableMember && !isTeamCol ? "bg-indigo-950/40" : ""
+                  // ピン留め列（日付・相手）と ○数 は行背景を敷く（○数はピン留めしないが集計列なので行背景を維持）。
+                  // 自メンバー列は編集中のみハイライト。team 列は bg を状態強調に使うため indigo bg は敷かない（編集可は下の ring で表現）
+                  let cellBg = pinned || col.id === "count" ? bg : editableMember && !isTeamCol ? "bg-indigo-950/40" : ""
                   // チーム単位モード列は、その日のセル状態に応じてセル全体を強調する（○=bg を上書き / ×=中身を薄く）。
                   // ○の強調 bg は成立行の背景に近い不透明の emerald 系（#112e28）。ピン留め相手team列でも視認性優先で行背景より優先する。
                   const emphasis = isTeamCol ? teamCellEmphasis(schedCol!.cells.get(r.date.key)?.status ?? "none") : null

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -73,7 +73,7 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
         // 祝日は日曜と同じ扱い（赤系）。祝日名はツールチップで補足する
         const wkColor = d.isSunday || d.isHoliday ? "text-rose-400" : d.isSaturday ? "text-sky-400" : "text-zinc-200"
         return (
-          <div className="flex flex-col items-start gap-0.5">
+          <div className="flex flex-col items-center gap-0.5 pt-1">
             <span className={"text-xs font-medium " + wkColor} title={d.holidayName ?? undefined}>
               {d.label}
               <span className="ml-0.5 text-[11px]">({d.weekday})</span>
@@ -224,12 +224,10 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, memberColumns, 
                   const fadeClass = r.impossible ? "opacity-70" : emphasis?.faded ? "opacity-60" : null
                   // ○数列だけ横padを半分にして（px-1.5→px-[3px]）活動可バッジの幅を確保する
                   const xPad = col.id === "count" ? "px-[3px]" : "px-1.5"
-                  // 日付列はボタン+入力欄を持つ他列より背が低いので、縦中央に揃える（他列は上揃え）
-                  const valign = col.id === "date" ? "align-middle" : "align-top"
                   return (
                     <td
                       key={cell.id}
-                      className={"border-b border-r border-zinc-700 py-1.5 text-center " + valign + " " + xPad + " " + cellBg + teamEditRing}
+                      className={"border-b border-r border-zinc-700 py-1.5 align-top text-center " + xPad + " " + cellBg + teamEditRing}
                       style={{ ...pinnedStyle(col, false), minWidth: col.getSize(), width: pinned ? col.getSize() : undefined }}
                     >
                       {fadeClass ? <div className={fadeClass}>{content}</div> : content}

--- a/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
+++ b/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
@@ -190,15 +190,16 @@ function OwnTeamDropdown({
         </button>
         {open && (
           <div className="absolute inset-x-0 z-10 mt-1 max-h-60 overflow-y-auto rounded-lg border border-zinc-600 bg-zinc-900 py-1 shadow-lg">
-            <button
-              type="button"
-              onClick={() => handleSelect(null)}
-              className="flex w-full items-center px-3 py-1.5 text-left hover:bg-zinc-800"
-            >
-              <span className={ownTeamId === null ? "text-indigo-300" : "text-zinc-400"}>
-                選択してください
-              </span>
-            </button>
+            {/* 「選択してください」は未選択時のプレースホルダのみ。チーム選択済みなら不要なので出さない */}
+            {ownTeamId === null && (
+              <button
+                type="button"
+                onClick={() => handleSelect(null)}
+                className="flex w-full items-center px-3 py-1.5 text-left hover:bg-zinc-800"
+              >
+                <span className="text-indigo-300">選択してください</span>
+              </button>
+            )}
             {teams.map((t) => {
               const isSelected = t.teamId === ownTeamId
               return (

--- a/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
+++ b/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
@@ -145,15 +145,16 @@ function OwnTeamDropdown({
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
-  // パネル外クリックで閉じる
+  // パネル外クリックで閉じる。pointerdown ではなく click で閉じるのが重要:
+  // pointerdown だと暗幕（DimOverlay）タップ時に pointerdown 段階で overlay が unmount され、
+  // 続く click が裏の要素にすり抜けてボタンが誤発火する（ゴーストクリック）。
   useEffect(() => {
     if (!open) return
-    const onPointerDown = (e: PointerEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false)
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
     }
-    document.addEventListener("pointerdown", onPointerDown)
-    return () => document.removeEventListener("pointerdown", onPointerDown)
+    document.addEventListener("click", onDocClick)
+    return () => document.removeEventListener("click", onDocClick)
   }, [open])
 
   const selected = teams.find((t) => t.teamId === ownTeamId) ?? null
@@ -237,15 +238,16 @@ function OpponentDropdown({
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
-  // パネル外クリックで閉じる
+  // パネル外クリックで閉じる。pointerdown ではなく click で閉じるのが重要:
+  // pointerdown だと暗幕（DimOverlay）タップ時に pointerdown 段階で overlay が unmount され、
+  // 続く click が裏の要素にすり抜けてボタンが誤発火する（ゴーストクリック）。
   useEffect(() => {
     if (!open) return
-    const onPointerDown = (e: PointerEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false)
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
     }
-    document.addEventListener("pointerdown", onPointerDown)
-    return () => document.removeEventListener("pointerdown", onPointerDown)
+    document.addEventListener("click", onDocClick)
+    return () => document.removeEventListener("click", onDocClick)
   }, [open])
 
   // 候補順を保ったまま選択中だけ抽出（トリガー内に1行で並べる）

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -82,6 +82,18 @@ export function TeamSchedulesPage() {
   // lg未満（カレンダーだけスクロールする縦圧縮レイアウト）で、表以外のチーム選択・凡例を畳んで
   // 表に縦スペースを譲る。lg以上では常に展開（トグルも非表示）。(#156)
   const [chromeCollapsed, setChromeCollapsed] = useState(false)
+  // 折りたたみ領域の overflow。畳みアニメ中は overflow-hidden で中身を隠す必要があるが、
+  // 展開しきった状態では自チーム/相手チームのドロップダウン（absolute）が領域外へ出られるよう
+  // overflow-visible にする（#156 のアニメと、未選択時にドロップダウンがグリッド案内文の後ろへ
+  // 隠れる不具合の両立）。畳む時は即クリップ、展開時はアニメ完了後（onTransitionEnd）に可視化する。
+  const [chromeOverflowVisible, setChromeOverflowVisible] = useState(true)
+  // 折りたたみトグル。畳む時は即クリップ（スライドを正しく見せる）、展開時はアニメ完了後
+  // （grid の onTransitionEnd）に overflow を可視化する。
+  const toggleChrome = () => {
+    const next = !chromeCollapsed
+    setChromeCollapsed(next)
+    if (next) setChromeOverflowVisible(false)
+  }
   // 選択の整合（後段の reconcile 効果で参照）。magic-link ログイン確立後の再取得で
   // false に戻し、正しい isMember を反映した teams でもう一度だけ走らせる。
   const reconciledRef = useRef(false)
@@ -830,7 +842,7 @@ export function TeamSchedulesPage() {
               {/* たたむボタン: 設定ボタンの左。表以外（チーム選択・凡例）を畳んで表に縦スペースを譲る（#156） */}
               <button
                 type="button"
-                onClick={() => setChromeCollapsed((v) => !v)}
+                onClick={toggleChrome}
                 aria-label={chromeCollapsed ? "チーム選択・凡例を開く" : "チーム選択・凡例をたたむ"}
                 aria-expanded={!chromeCollapsed}
                 title={chromeCollapsed ? "開く" : "たたむ"}
@@ -882,7 +894,7 @@ export function TeamSchedulesPage() {
               {/* たたむボタン: 設定ボタンの左。md〜lg未満（縦圧縮レイアウト）でのみ表示（#156） */}
               <button
                 type="button"
-                onClick={() => setChromeCollapsed((v) => !v)}
+                onClick={toggleChrome}
                 aria-label={chromeCollapsed ? "チーム選択・凡例を開く" : "チーム選択・凡例をたたむ"}
                 aria-expanded={!chromeCollapsed}
                 title={chromeCollapsed ? "開く" : "たたむ"}
@@ -910,8 +922,14 @@ export function TeamSchedulesPage() {
 
         {/* チーム選択・凡例の折りたたみ領域（#156）。grid-rows 0fr↔1fr で高さを上下スライドアニメーション。
             lg以上は常に展開（トグルも非表示）。inner は overflow-hidden で畳み時に中身を隠す。 */}
-        <div className={"grid shrink-0 transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] " + (chromeCollapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]")}>
-          <div className="min-h-0 overflow-hidden">
+        <div
+          className={"grid shrink-0 transition-[grid-template-rows] duration-300 ease-in-out lg:grid-rows-[1fr] " + (chromeCollapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]")}
+          onTransitionEnd={(e) => {
+            // 展開アニメ完了時のみ overflow を可視化（ドロップダウンが領域外へ出られるように）
+            if (e.propertyName === "grid-template-rows" && !chromeCollapsed) setChromeOverflowVisible(true)
+          }}
+        >
+          <div className={"min-h-0 " + (chromeOverflowVisible ? "overflow-visible" : "overflow-hidden")}>
             <div className="flex flex-col md:gap-3 gap-1.5">
               <TeamCompareSelector teams={teams} ownTeamId={ownTeamId} opponentTeamIds={opponentTeamIds} onOwnTeamChange={setOwnTeamId} onOpponentsChange={setOpponentTeamIds} />
               {view && <ControlBar threshold={view.threshold} managementMode={view.managementMode} />}

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -789,7 +789,7 @@ export function TeamSchedulesPage() {
 
     // team モードは単一状態（ok=活動可能）なので閾値は 1
     const threshold = ownTeam.managementMode === "team" ? 1 : ownTeam.requiredCount
-    return { memberColumns, opponentColumns, rows, threshold, managementMode: ownTeam.managementMode }
+    return { memberColumns, opponentColumns, rows, threshold, managementMode: ownTeam.managementMode, ownTeamName: ownTeam.name }
   }, [ownTeamId, opponentTeamIds, schedulesByTeam, dates, dayKeys, session])
 
   // 自分が1つでもチームに所属しているか（teams 一覧の isMember 由来）。md以下で「チームを作成」ボタンを隠す判定に使う。
@@ -941,6 +941,7 @@ export function TeamSchedulesPage() {
                 threshold={view.threshold}
                 opponentColumns={view.opponentColumns}
                 memberColumns={view.memberColumns}
+                ownTeamName={view.ownTeamName}
                 onCycle={handleCycle}
                 onNoteChange={handleNoteChange}
                 onTeamCycle={handleTeamCycle}

--- a/my-app/drizzle.config.ts
+++ b/my-app/drizzle.config.ts
@@ -1,4 +1,4 @@
-import "dotenv/config"
+import "./scripts/loadEnv.mjs"
 import { defineConfig } from "drizzle-kit"
 
 // マイグレーション生成・適用の設定。

--- a/my-app/scripts/infra/diagnose-migrations.mjs
+++ b/my-app/scripts/infra/diagnose-migrations.mjs
@@ -9,9 +9,9 @@
 // drizzle-kit migrate がエラーを握り潰すため、ここでは __drizzle_migrations の
 // 適用記録と、実際に存在するテーブル/カラム/制約を SELECT で読み出して突き合わせる。
 
-// my-app/.env を読み込む（drizzle.config.ts と同じ挙動）。
-// 既に環境変数で DATABASE_URL が渡っていればそちらが優先される（dotenv は上書きしない）。
-import "dotenv/config"
+// my-app の .env.local / .env を next dev と同じ優先順位で読み込む（drizzle.config.ts と同じ挙動）。
+// 既に環境変数で DATABASE_URL が渡っていればそちらが優先される（ファイルでは上書きしない）。
+import "../loadEnv.mjs"
 import { Pool } from "pg"
 
 const url = process.env.DATABASE_URL

--- a/my-app/scripts/infra/reset-db.mjs
+++ b/my-app/scripts/infra/reset-db.mjs
@@ -22,8 +22,9 @@
 //    （実行ブランチに応じた environment の DATABASE_URL secret で migrate が走る）。
 // 4. run が緑になれば __drizzle_migrations と実スキーマが一致した状態になる。
 
-// my-app/.env を読み込む。環境変数で DATABASE_URL が渡っていればそちらが優先される。
-import "dotenv/config"
+// my-app の .env.local / .env を next dev と同じ優先順位で読み込む。
+// 環境変数で DATABASE_URL が渡っていればそちらが優先される（ファイルでは上書きしない）。
+import "../loadEnv.mjs"
 import { Pool } from "pg"
 
 const url = process.env.DATABASE_URL

--- a/my-app/scripts/loadEnv.mjs
+++ b/my-app/scripts/loadEnv.mjs
@@ -1,0 +1,23 @@
+// ローカル開発ツール（drizzle-kit / seed スクリプト / infra スクリプト 等）用の env ローダー。
+//
+// 素の `import "dotenv/config"` は `.env` しか読まないため、`next dev` が読む
+// `.env.local` 等に置いた値を拾えず、「seed/migrate は .env、dev は .env.local」と
+// 接続先がズレる事故が起きる。ここでは next dev と同じ優先順位に揃える。
+//
+// 優先順位（高い方が勝つ）:
+//   process.env（シェルの export / `VAR=x node ...` の CLI 指定）
+//     > .env.development.local > .env.local > .env.development > .env
+//
+// dotenv はデフォルト（override なし）で「既に設定済みのキーは上書きしない」ため、
+// 高い優先度のファイルから順に読み込めば、先に設定された値が残る。
+// これにより (1) シェルで渡した値が常に勝つ＝スクリプトの `VAR=x node ...` 上書きを維持しつつ、
+// (2) ファイル間では next dev と同じく .env.local が .env に勝つ、を両立する。
+//
+// 注意: dotenv のパス解決は process.cwd() 基準（モジュール位置ではない）。
+// これらのツールは my-app 直下で実行する前提なので、相対パスはそこに解決される。
+import { config } from "dotenv"
+
+config({ path: ".env.development.local" })
+config({ path: ".env.local" })
+config({ path: ".env.development" })
+config({ path: ".env" })

--- a/my-app/scripts/team-schedules/creator-login-links.mjs
+++ b/my-app/scripts/team-schedules/creator-login-links.mjs
@@ -13,15 +13,15 @@
 //   node scripts/team-schedules/creator-login-links.mjs                 # member作成 + ログインURL発行
 //   node scripts/team-schedules/creator-login-links.mjs --login-only    # 作成せず、既存ユーザーのログインURLだけ再発行
 //
-// 接続先は my-app/.env の DATABASE_URL / REDIS_URL / APP_URL を使う
-// （コマンド先頭で `APP_URL=http://localhost:3000 node ...` のように上書きも可能）。
+// 接続先は my-app の .env.local / .env の DATABASE_URL / REDIS_URL / APP_URL を使う
+// （next dev と同じ優先順位。コマンド先頭で `APP_URL=http://localhost:3000 node ...` のように上書きも可能）。
 // 注意: magic-link は「dev サーバーが読む Redis」に書く必要があるため、
 //       REDIS_URL は起動中の next dev と同じものを指すこと。
 //
 // 安全弁: DATABASE_URL が neon.tech（本番/プレビュー想定）の場合は、
 //         誤爆防止のため CONFIRM_SEED=yes を付けないと実行できない。
 
-import "dotenv/config"
+import "../loadEnv.mjs"
 import { randomBytes } from "crypto"
 import { Pool } from "pg"
 import { createClient } from "redis"

--- a/my-app/scripts/team-schedules/seed-team-schedules.mjs
+++ b/my-app/scripts/team-schedules/seed-team-schedules.mjs
@@ -1,7 +1,8 @@
 // スクリム調整機能（/team_schedules）のローカル動作確認用シードスクリプト。
 //
 // Discord 経由でしかチーム/ユーザーを作れないため、ローカルDBに
-// 「管理者(master)1人 + 一般メンバー2人 + チーム1つ + 数日ぶんの予定」を投入し、
+// 「チーム1つ + 管理者(master)1人 + 一般メンバーA1人（ここまでチーム所属）
+//   + チーム未参加のB1人（ログインのみ・非メンバー体験のテスト用） + 数日ぶんの予定」を投入し、
 // 各ユーザーの magic-link ログインURL（Redis のワンタイムトークン）を発行する。
 // 発行したURLをブラウザで開けば、Discord を介さずにそのユーザーとしてログインできる。
 //
@@ -9,16 +10,19 @@
 //   cd my-app
 //   node scripts/team-schedules/seed-team-schedules.mjs                 # シード + 全ユーザーのログインURL発行
 //   node scripts/team-schedules/seed-team-schedules.mjs --login-only    # シードせず、ログインURLだけ再発行（トークン失効時）
+//   EXTRA_MEMBERS=10 node scripts/team-schedules/seed-team-schedules.mjs # 固定3人に加え、一般メンバーを10人ぶん自動生成して投入
+//   （Makefile からは `make seed MEMBERS=10` で同じことができる）
+//   ※ EXTRA_MEMBERS は --login-only でも同じ数を指定すること（生成メンバーぶんのログインURLを再発行するため）
 //
-// 接続先は my-app/.env の DATABASE_URL / REDIS_URL / APP_URL を使う
-// （コマンド先頭で `APP_URL=http://localhost:3000 node ...` のように上書きも可能）。
+// 接続先は my-app の .env.local / .env の DATABASE_URL / REDIS_URL / APP_URL を使う
+// （next dev と同じ優先順位。コマンド先頭で `APP_URL=http://localhost:3000 node ...` のように上書きも可能）。
 // 注意: magic-link は「dev サーバーが読む Redis」に書く必要があるため、
 //       REDIS_URL は起動中の next dev と同じものを指すこと。
 //
 // 安全弁: DATABASE_URL が neon.tech（本番/プレビュー想定）の場合は、
 //         誤爆防止のため CONFIRM_SEED=yes を付けないと実行できない。
 
-import "dotenv/config"
+import "../loadEnv.mjs"
 import { randomBytes } from "crypto"
 import { Pool } from "pg"
 import { createClient } from "redis"
@@ -29,12 +33,28 @@ const MAGIC_LINK_TTL = Number(process.env.MAGIC_LINK_TTL_SECONDS ?? 3600) // dev
 
 const TEAM = { teamId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", name: "テストチーム（管理用）", description: "ローカル動作確認用のシードチーム", requiredCount: 3, managementMode: "members" }
 
-// teamRole: master = 管理者（チームに1人）, member = 一般
-const SEED_USERS = [
+// teamRole: master = 管理者（チームに1人）, member = 一般メンバー, null = チーム未参加
+// （null はユーザー/ログインだけ作り、チームには入れない。非メンバーから見た表示のテスト用）
+const BASE_USERS = [
   { userId: "11111111-1111-4111-8111-111111111111", discordUserId: "900000000000000001", displayName: "テスト管理者", teamRole: "master" },
   { userId: "22222222-2222-4222-8222-222222222222", discordUserId: "900000000000000002", displayName: "テストメンバーA", teamRole: "member" },
-  { userId: "33333333-3333-4333-8333-333333333333", discordUserId: "900000000000000003", displayName: "テストメンバーB", teamRole: "member" },
+  { userId: "33333333-3333-4333-8333-333333333333", discordUserId: "900000000000000003", displayName: "テストメンバーB", teamRole: null },
 ]
+
+// EXTRA_MEMBERS=N で、固定3人に加えて一般メンバー(member)を N 人ぶん自動生成する。
+// 冪等にするため、index から決め打ちの UUID / Discord ID を組み立てる（再実行で同じ人に上書きされる）。
+const extraMembers = Math.max(0, Math.floor(Number(process.env.EXTRA_MEMBERS ?? 0)) || 0)
+const GENERATED_USERS = Array.from({ length: extraMembers }, (_, idx) => {
+  const n = idx + 1
+  return {
+    userId: `cccccccc-cccc-4ccc-8ccc-${String(n).padStart(12, "0")}`,
+    discordUserId: `9000001${String(n).padStart(11, "0")}`, // 7 + 11 = 18桁（Discord snowflake と同じ桁数）
+    displayName: `自動メンバー${n}`,
+    teamRole: "member",
+  }
+})
+
+const SEED_USERS = [...BASE_USERS, ...GENERATED_USERS]
 
 const loginOnly = process.argv.includes("--login-only")
 
@@ -103,8 +123,14 @@ async function seed(pool) {
     [TEAM.teamId, TEAM.name, TEAM.description, TEAM.requiredCount, TEAM.managementMode],
   )
 
-  // team_members（ロールは常に整合させる）
+  // team_members: teamRole があるユーザーだけ登録（ロールは常に整合させる）。
+  // teamRole=null（未参加）は、過去の seed で参加済みだった場合に備えて所属と予定を掃除する。
   for (const u of SEED_USERS) {
+    if (u.teamRole === null) {
+      await pool.query(`DELETE FROM team_members WHERE team_id = $1 AND user_id = $2`, [TEAM.teamId, u.userId])
+      await pool.query(`DELETE FROM schedules WHERE team_id = $1 AND user_id = $2`, [TEAM.teamId, u.userId])
+      continue
+    }
     await pool.query(
       `INSERT INTO team_members (team_id, user_id, team_role) VALUES ($1, $2, $3)
        ON CONFLICT (team_id, user_id) DO UPDATE SET team_role = EXCLUDED.team_role`,
@@ -112,11 +138,13 @@ async function seed(pool) {
     )
   }
 
-  // schedules（members モードのグリッドが空にならないよう、今日から数日ぶんを投入）
+  // schedules（members モードのグリッドが空にならないよう、今日から数日ぶんを投入）。
+  // チーム所属メンバー（teamRole != null）のぶんだけ入れる。
+  const members = SEED_USERS.filter((u) => u.teamRole !== null)
   const statuses = ["ok", "maybe", "ng"]
   let count = 0
-  for (let i = 0; i < SEED_USERS.length; i++) {
-    const u = SEED_USERS[i]
+  for (let i = 0; i < members.length; i++) {
+    const u = members[i]
     for (let d = 0; d < 4; d++) {
       // ユーザー/日でずらして ok/maybe/ng を散らす
       const status = statuses[(i + d) % statuses.length]
@@ -130,7 +158,8 @@ async function seed(pool) {
     }
   }
 
-  console.log(`シード完了: team「${TEAM.name}」/ users ${SEED_USERS.length}人 / schedules ${count}行`)
+  const nonMembers = SEED_USERS.length - members.length
+  console.log(`シード完了: team「${TEAM.name}」/ メンバー ${members.length}人 + 未参加 ${nonMembers}人 / schedules ${count}行`)
 }
 
 // --- magic-link 発行（Redis書き込み） ---------------------------------------
@@ -142,7 +171,7 @@ async function issueLoginLinks(redis) {
     // login.ts と同じ形: key=ts:magic:{token}, value={discordUserId, username}
     const payload = JSON.stringify({ discordUserId: u.discordUserId, username: u.displayName })
     await redis.setEx(`ts:magic:${token}`, MAGIC_LINK_TTL, payload)
-    const roleLabel = u.teamRole === "master" ? "管理者(master)" : "メンバー"
+    const roleLabel = u.teamRole === "master" ? "管理者(master)" : u.teamRole === "member" ? "メンバー" : "未参加（チーム未所属）"
     lines.push(`  [${roleLabel}] ${u.displayName}\n    ${appUrl}/team_schedules?token=${token}`)
   }
   const expiryMinutes = Math.round(MAGIC_LINK_TTL / 60)


### PR DESCRIPTION
## 概要

前回リリース（PR #169）以降に develop へ入った変更を main へリリースする。

## 含まれる変更

- **PR #170** fix/feat: team_schedules 表の表示調整
  - 無効ボタンのカーソルを矢印に（Tailwind v4 のレイヤー順対策で `cursor-default!`）
  - 日付列を `pt-1`・横中央に配置
  - ○数列ヘッダーの上に自チーム名を固定幅で表示（2段ヘッダー化）
  - 自チーム未選択時にドロップダウンが隠れる不具合を修正
  - 比較ドロップダウンで暗幕タップ時の裏ボタン誤発火を修正

- **PR #173** chore: team_schedules ローカル開発ツール整備（UI 変更なし）
  - 共有 env ローダー `scripts/loadEnv.mjs` を追加し drizzle-kit / seed / infra を `next dev` と同じ優先順位に統一
  - seed 拡張（チーム未参加メンバー・`EXTRA_MEMBERS=N`）
  - Makefile 追加（db/redis 起動・migrate・seed・dev）

## close する issue

- Closes #163 （PR #170 の「○数列ヘッダーの上に自チーム名を固定表示」で、close 時にチーム名が見えなくなる問題に対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)