### PR TITLE
feat: スクリム調整に管理画面・利用停止/Discord BAN を追加（往復削減・BAN理由上書き含む）

### DIFF
--- a/.claude/rules/coding-standards.md
+++ b/.claude/rules/coding-standards.md
@@ -28,10 +28,13 @@
   **必ずユーザーに確認してから**実行する（勝手に force-push しない）。
 
 
-- **feature → develop の PR**: その PR で完了させる issue を本文に `- close #N` の形式で**列挙**する
-  （`#N` は GitHub 上で issue タイトルがリンク表示されるため、タイトルは書かない。develop base では `Closes #N` でも
-  auto-close は発火しないので、ここでは close せず一覧として残す目的。develop→main PR を組むときの拾い漏れ防止）。
+- **feature → develop の PR**: その PR で完了させる issue を本文に `- #N` の形式で**列挙**する
+  （`#N` は GitHub 上で issue タイトルがリンク表示されるため、タイトルは書かない。
+  `close` / `closes` / `fix` / `resolves` 等のクローズキーワードは**絶対に付けない** —
+  これらは大文字小文字を問わず予約語で、PR の base を main に付け替えた瞬間などに意図せず auto-close が発火する。
+  ここは develop→main PR を組むときの拾い漏れ防止の一覧であって、閉じる指示ではない）。
 - **develop → main の PR**: 束ねた close予定 issue を `Closes #N` で本文に列挙する → main マージ時に auto-close される（手動 close 不要）。
+  クローズキーワードを使うのは**この develop→main PR だけ**。
 - フォローアップとして**新規起票した issue は列挙しない**（その PR では閉じないため）。
 - やむを得ず develop の時点で閉じる場合のみ `gh issue close #N -c "..."` で手動 close する。
 

--- a/my-app/app/_client/lib/apiClient/teamSchedulesAdmin.ts
+++ b/my-app/app/_client/lib/apiClient/teamSchedulesAdmin.ts
@@ -1,0 +1,82 @@
+import type { AdminDiscordBan, AdminOverview } from "@/app/_domains/teamSchedules/types"
+
+/**
+ * スクリム調整 管理API（/api/web/team-schedules/admin/**）のクライアント（#166）。
+ *
+ * 開発者ログイン（localStorage.sessionToken の Bearer）を流用する（crud.ts と同じ流儀）。
+ * 利用者の ts_session（Cookie）とは別系統。トークンが無ければ呼び出し前に例外を投げる。
+ */
+
+const API_BASE = "/api/web/team-schedules/admin"
+
+type ApiResult<T> = { success: boolean; error?: string } & T
+
+/** localStorage の開発者セッショントークンを取得（無ければ例外） */
+function getAdminToken(): string {
+  const token = typeof window !== "undefined" ? localStorage.getItem("sessionToken") : null
+  if (!token) throw new Error("セッショントークンがありません。ログインしてください。")
+  return token
+}
+
+/** Bearer 認証付き fetch ＋ レスポンス検証（crud.ts / teamSchedulesApiClient.ts の流儀を統合） */
+async function request<T>(endpoint: string, init: { method: string; body?: object }, fallbackError: string): Promise<ApiResult<T>> {
+  const headers: Record<string, string> = { Authorization: `Bearer ${getAdminToken()}` }
+  if (init.body !== undefined) headers["Content-Type"] = "application/json"
+
+  const res = await fetch(`${API_BASE}${endpoint}`, {
+    method: init.method,
+    headers,
+    body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+    cache: "no-store",
+  })
+  const json = (await res.json().catch(() => null)) as ApiResult<T> | null
+  if (!res.ok || !json?.success) {
+    throw new Error(json?.error ?? `${fallbackError}（HTTP ${res.status}）`)
+  }
+  return json
+}
+
+/** 全チーム＋設定＋メンバー＋無所属ユーザーを取得 */
+export async function fetchAdminOverview(): Promise<AdminOverview> {
+  const json = await request<AdminOverview>("/overview", { method: "GET" }, "管理データの取得に失敗しました")
+  return { teams: json.teams ?? [], orphanUsers: json.orphanUsers ?? [] }
+}
+
+/** チームを強制解散する（取り消し不可） */
+export async function adminDeleteTeam(teamId: string): Promise<void> {
+  await request(`/teams/${encodeURIComponent(teamId)}`, { method: "DELETE" }, "チームの解散に失敗しました")
+}
+
+/** メンバーをチームから除外する */
+export async function adminRemoveMember(teamId: string, userId: string): Promise<void> {
+  await request(`/teams/${encodeURIComponent(teamId)}/members/${encodeURIComponent(userId)}`, { method: "DELETE" }, "メンバーの除外に失敗しました")
+}
+
+/** ユーザーアカウントを完全削除する（取り消し不可） */
+export async function adminDeleteUser(userId: string): Promise<void> {
+  await request(`/users/${encodeURIComponent(userId)}`, { method: "DELETE" }, "ユーザーの削除に失敗しました")
+}
+
+/** ユーザーの利用停止状態を切り替える（true=停止 / false=解除） */
+export async function adminSetSuspended(userId: string, suspended: boolean): Promise<void> {
+  const path = `/users/${encodeURIComponent(userId)}/suspend`
+  await request(path, { method: suspended ? "POST" : "DELETE" }, "利用停止状態の更新に失敗しました")
+}
+
+/** Discord BAN 一覧を取得 */
+export async function fetchDiscordBans(): Promise<AdminDiscordBan[]> {
+  const json = await request<{ bans?: AdminDiscordBan[] }>("/discord-bans", { method: "GET" }, "BAN 一覧の取得に失敗しました")
+  return json.bans ?? []
+}
+
+/** Discord ID を BAN に追加する */
+export async function addDiscordBan(discordUserId: string, reason: string | null): Promise<AdminDiscordBan> {
+  const json = await request<{ ban?: AdminDiscordBan }>("/discord-bans", { method: "POST", body: { discordUserId, reason } }, "BAN の追加に失敗しました")
+  if (!json.ban) throw new Error("BAN の追加に失敗しました")
+  return json.ban
+}
+
+/** Discord ID の BAN を解除する */
+export async function removeDiscordBan(discordUserId: string): Promise<void> {
+  await request(`/discord-bans/${encodeURIComponent(discordUserId)}`, { method: "DELETE" }, "BAN の解除に失敗しました")
+}

--- a/my-app/app/_domains/teamSchedules/_server/authz.ts
+++ b/my-app/app/_domains/teamSchedules/_server/authz.ts
@@ -41,6 +41,36 @@ export async function isUserSuspended(userId: string): Promise<boolean> {
   return rows[0]?.suspended === true
 }
 
+/** getTeamMembershipWithSuspension の戻り値 */
+export type TeamMembershipWithSuspension = {
+  /** 利用停止中か（users.suspended）。非メンバーでも必ず取れる */
+  suspended: boolean
+  /** チーム内ロール（非メンバーは null） */
+  teamRole: TeamRole | null
+}
+
+/**
+ * (teamId, userId) のチーム内ロールと、そのユーザーの利用停止状態を「1クエリ」で返す（#166）。
+ *
+ * このアプリはインフラ都合で1クエリごとにコネクションを貼り直すため DB 往復が高コスト。
+ * 書き込み系 API では従来 isUserSuspended（users）と getTeamRole/assertTeamMember/assertTeamAdmin
+ * （team_members）で2往復していたのを、users を基点に team_members を LEFT JOIN して1往復に畳む。
+ *
+ * users 起点の LEFT JOIN なので、非メンバーでも suspended は必ず取れる（teamRole だけ null になる）。
+ * 呼び出し側は「suspended → 403」を先に、「teamRole → 404/400」を必要な箇所で判定すれば、
+ * 従来と同じ順序・レスポンスを保てる（ロール判定は getTeamRole 等と同じ意味）。
+ */
+export async function getTeamMembershipWithSuspension(teamId: string, userId: string): Promise<TeamMembershipWithSuspension> {
+  const rows = await db
+    .select({ suspended: users.suspended, teamRole: teamMembers.teamRole })
+    .from(users)
+    .leftJoin(teamMembers, and(eq(teamMembers.userId, users.userId), eq(teamMembers.teamId, teamId)))
+    .where(eq(users.userId, userId))
+    .limit(1)
+  const row = rows[0]
+  return { suspended: row?.suspended === true, teamRole: row?.teamRole ?? null }
+}
+
 /** (teamId, userId) が team_members に存在するか（＝そのチームの編集権がある人か） */
 export async function assertTeamMember(teamId: string, userId: string): Promise<boolean> {
   const rows = await db

--- a/my-app/app/_domains/teamSchedules/_server/authz.ts
+++ b/my-app/app/_domains/teamSchedules/_server/authz.ts
@@ -11,7 +11,7 @@
 import { and, eq } from "drizzle-orm"
 import type { NextRequest } from "next/server"
 import { db } from "@/app/_server/lib/db"
-import { discordLinks, teamMembers } from "./schema"
+import { discordLinks, teamMembers, users } from "./schema"
 import { hasAdminAuthority, type TeamRole } from "@/app/_domains/teamSchedules/types"
 import { getUserIdFromSession } from "./session"
 import { TEAM_SCHEDULE_CREATOR_DISCORD_IDS } from "@/app/_server/lib/env"
@@ -26,6 +26,19 @@ const creatorDiscordIds = new Set(
 /** ログイン中ユーザーID（未認証は null） */
 export async function getSessionUserId(request: NextRequest): Promise<string | null> {
   return getUserIdFromSession(request)
+}
+
+/**
+ * このユーザーが利用停止（suspended）中か（#166）。
+ * 書き込み系 API で「ログイン確認 → suspend なら 403」の判定に使う（読み取りは透過）。
+ *
+ * 適用範囲: 新規コンテンツ・参加を作る書き込み（チーム作成 / 参加 / 招待発行 / 予定・チーム状態の編集 /
+ *   master移譲 / チーム設定編集・解散）はガード対象。一方、自己片付け（チーム脱退 = membership DELETE /
+ *   アカウント削除 = account DELETE）は suspend 中でも許可する（footprint を減らす操作は止めない方針）。
+ */
+export async function isUserSuspended(userId: string): Promise<boolean> {
+  const rows = await db.select({ suspended: users.suspended }).from(users).where(eq(users.userId, userId)).limit(1)
+  return rows[0]?.suspended === true
 }
 
 /** (teamId, userId) が team_members に存在するか（＝そのチームの編集権がある人か） */

--- a/my-app/app/_domains/teamSchedules/_server/bans.ts
+++ b/my-app/app/_domains/teamSchedules/_server/bans.ts
@@ -1,0 +1,46 @@
+/**
+ * スクリム調整機能 - Discord ID の BAN（ブラックリスト）操作（#166）
+ *
+ * magic-link でのセルフサインアップ/ログインを遮断するための仕組み。
+ * 判定は auth/verify（新規ログイン時）でのみ行う。
+ *
+ * ↓注意: 既に ts_session（最大30日）を持つユーザーは、後から BAN されても
+ *        利用者ページ側の API では弾かれず素通りする（即時失効は将来対応）。
+ *        利用者側 API で BAN 強制を入れる場合は isDiscordBanned をその起点として使う。
+ */
+
+import { desc, eq } from "drizzle-orm"
+import { db } from "@/app/_server/lib/db"
+import { discordBans, type DiscordBan } from "./schema"
+
+/** この Discord ID が BAN されているか */
+export async function isDiscordBanned(discordUserId: string): Promise<boolean> {
+  const rows = await db.select({ discordUserId: discordBans.discordUserId }).from(discordBans).where(eq(discordBans.discordUserId, discordUserId)).limit(1)
+  return rows.length > 0
+}
+
+/** BAN 済み Discord ID の一覧（新しい順） */
+export async function listDiscordBans(): Promise<DiscordBan[]> {
+  return db.select().from(discordBans).orderBy(desc(discordBans.bannedAt))
+}
+
+/**
+ * Discord ID を BAN に追加する（理由は任意）。既に存在する場合は理由を上書きしない（冪等）。
+ * 追加された行を返す（既存なら既存行）。
+ */
+export async function addDiscordBan(discordUserId: string, reason: string | null): Promise<DiscordBan> {
+  const inserted = await db.insert(discordBans).values({ discordUserId, reason }).onConflictDoNothing({ target: discordBans.discordUserId }).returning()
+  if (inserted[0]) return inserted[0]
+  // 既に BAN 済み（onConflictDoNothing で 0 行）。既存行を引いて返す。
+  // neon-http はトランザクション非対応のため、INSERT と SELECT の極小区間で当該行が
+  // 削除されると 0 行になり得る（admin 専用フローなので実質起こらないが）。その場合は例外にする。
+  const existing = await db.select().from(discordBans).where(eq(discordBans.discordUserId, discordUserId)).limit(1)
+  if (!existing[0]) throw new Error("BAN 行の取得に失敗しました")
+  return existing[0]
+}
+
+/** Discord ID の BAN を解除する。削除できたら true（存在しなければ false） */
+export async function removeDiscordBan(discordUserId: string): Promise<boolean> {
+  const deleted = await db.delete(discordBans).where(eq(discordBans.discordUserId, discordUserId)).returning({ discordUserId: discordBans.discordUserId })
+  return deleted.length > 0
+}

--- a/my-app/app/_domains/teamSchedules/_server/bans.ts
+++ b/my-app/app/_domains/teamSchedules/_server/bans.ts
@@ -25,18 +25,19 @@ export async function listDiscordBans(): Promise<DiscordBan[]> {
 }
 
 /**
- * Discord ID を BAN に追加する（理由は任意）。既に存在する場合は理由を上書きしない（冪等）。
- * 追加された行を返す（既存なら既存行）。
+ * Discord ID を BAN に追加する（理由は任意）。
+ * 既に BAN 済みの ID を再 BAN した場合は理由と BAN 日時を上書きする（upsert）。
+ * 「理由を直したくて再登録したのに旧理由のまま」を防ぐため、冪等な no-op ではなく更新する。
+ * 追加/更新後の行を返す（onConflictDoUpdate は競合時も必ず1行返すため、追加 SELECT は不要）。
  */
 export async function addDiscordBan(discordUserId: string, reason: string | null): Promise<DiscordBan> {
-  const inserted = await db.insert(discordBans).values({ discordUserId, reason }).onConflictDoNothing({ target: discordBans.discordUserId }).returning()
-  if (inserted[0]) return inserted[0]
-  // 既に BAN 済み（onConflictDoNothing で 0 行）。既存行を引いて返す。
-  // neon-http はトランザクション非対応のため、INSERT と SELECT の極小区間で当該行が
-  // 削除されると 0 行になり得る（admin 専用フローなので実質起こらないが）。その場合は例外にする。
-  const existing = await db.select().from(discordBans).where(eq(discordBans.discordUserId, discordUserId)).limit(1)
-  if (!existing[0]) throw new Error("BAN 行の取得に失敗しました")
-  return existing[0]
+  const rows = await db
+    .insert(discordBans)
+    .values({ discordUserId, reason })
+    .onConflictDoUpdate({ target: discordBans.discordUserId, set: { reason, bannedAt: new Date() } })
+    .returning()
+  if (!rows[0]) throw new Error("BAN 行の取得に失敗しました")
+  return rows[0]
 }
 
 /** Discord ID の BAN を解除する。削除できたら true（存在しなければ false） */

--- a/my-app/app/_domains/teamSchedules/_server/schema.ts
+++ b/my-app/app/_domains/teamSchedules/_server/schema.ts
@@ -39,6 +39,9 @@ export const users = pgTable("users", {
   userId: uuid("user_id").primaryKey().defaultRandom(),
   displayName: text("display_name").notNull(), // 重複OK（ログインは一覧から選んで解決）
   passwordHash: text("password_hash").notNull(), // bcrypt。平文は入れない（認証方式が確定したら削除を検討）
+  // 利用停止フラグ（#166）。true の間は書き込み系 API が 403 を返す（読み取りは透過）。解除可能。
+  // 既ログインユーザーへの即時失効はせず、新規操作の遮断のみ（管理画面の運用手段）。
+  suspended: boolean("suspended").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 })
 
@@ -133,6 +136,14 @@ export const discordLinks = pgTable(
   (t) => [index("idx_discord_links_user").on(t.userId)],
 )
 
+// discord_bans: magic-link ログイン/サインアップを遮断する Discord ID のブラックリスト（#166）
+// auth/verify（新規ログイン時）でのみ判定する。既に ts_session を持つユーザーの即時失効は将来対応。
+export const discordBans = pgTable("discord_bans", {
+  discordUserId: text("discord_user_id").primaryKey(), // Discordのsnowflake。discord_links とは独立（FKは張らない）
+  reason: text("reason"), // BAN 理由（任意・運用メモ）
+  bannedAt: timestamp("banned_at", { withTimezone: true }).notNull().defaultNow(),
+})
+
 // 推論される型（クエリ結果や INSERT 値に効く）
 export type Team = typeof teams.$inferSelect
 export type NewTeam = typeof teams.$inferInsert
@@ -146,3 +157,5 @@ export type TeamDayStatus = typeof teamDayStatus.$inferSelect
 export type NewTeamDayStatus = typeof teamDayStatus.$inferInsert
 export type DiscordLink = typeof discordLinks.$inferSelect
 export type NewDiscordLink = typeof discordLinks.$inferInsert
+export type DiscordBan = typeof discordBans.$inferSelect
+export type NewDiscordBan = typeof discordBans.$inferInsert

--- a/my-app/app/_domains/teamSchedules/types.ts
+++ b/my-app/app/_domains/teamSchedules/types.ts
@@ -110,3 +110,57 @@ export type SessionUser = {
   /** チーム作成権限を持つか（ENV の許可 Discord ID） */
   canCreateTeam: boolean
 }
+
+// ───────────────────────────────────────────────────────────
+// 管理画面（開発者用 /developers/team-schedules）専用の型（#166）
+// admin 認証済みのため Discord ID / suspended を含めてよい
+// （通常の利用者 API では返さない方針を維持する）。
+// ───────────────────────────────────────────────────────────
+
+/** 管理画面に表示するチームメンバー（Discord ID・suspended 含む） */
+export type AdminTeamMember = {
+  userId: string
+  displayName: string
+  teamRole: TeamRole
+  /** 利用停止中か */
+  suspended: boolean
+  /** このユーザーに紐づく Discord ID（0件以上） */
+  discordUserIds: string[]
+  roles: LolRoleFlags
+}
+
+/** 管理画面に表示するチーム（設定＋メンバー一覧） */
+export type AdminTeam = {
+  teamId: string
+  name: string
+  description: string | null
+  requiredCount: number
+  managementMode: TeamManagementMode
+  /** 作成日時（ISO8601 文字列） */
+  createdAt: string
+  members: AdminTeamMember[]
+}
+
+/** どのチームにも所属していないユーザー（掃除対象の候補） */
+export type AdminOrphanUser = {
+  userId: string
+  displayName: string
+  suspended: boolean
+  discordUserIds: string[]
+  /** 作成日時（ISO8601 文字列） */
+  createdAt: string
+}
+
+/** GET /admin/overview のレスポンス本体 */
+export type AdminOverview = {
+  teams: AdminTeam[]
+  orphanUsers: AdminOrphanUser[]
+}
+
+/** Discord BAN 1件 */
+export type AdminDiscordBan = {
+  discordUserId: string
+  reason: string | null
+  /** BAN 日時（ISO8601 文字列） */
+  bannedAt: string
+}

--- a/my-app/app/api/web/team-schedules/account/route.ts
+++ b/my-app/app/api/web/team-schedules/account/route.ts
@@ -16,6 +16,10 @@ import { TS_SESSION_COOKIE, deleteUserSession, sessionCookieOptions } from "@/ap
  *
  * master を持つチームがある場合は削除不可（チームに master が必ず1人必要なため孤児化を防ぐ）。
  * 先に別メンバーへ管理者を移譲してから削除する想定 → 403。
+ *
+ * #166: 利用停止中（suspended）でもアカウント削除は許可する（isUserSuspended ガードを意図的に付けない）。
+ *       suspend は新規コンテンツ・参加の遮断が目的で、自己片付け（削除・脱退）は止めない方針
+ *       （membership DELETE と同じ割り切り）。
  */
 export async function DELETE(req: NextRequest): Promise<NextResponse> {
   try {

--- a/my-app/app/api/web/team-schedules/admin/_auth.ts
+++ b/my-app/app/api/web/team-schedules/admin/_auth.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server"
+import { validateAuthHeader } from "@/app/_server/lib/auth"
+
+/**
+ * スクリム調整 管理API 共通の認証ガード（#166）。
+ *
+ * 開発者ログイン（`/developers/redis` と同じ流儀）を流用する。
+ * Authorization ヘッダーを `validateAuthHeader`（Bearer = 開発者セッション / Basic = ALLOWED_USERS）で検証し、
+ * NG なら 401 レスポンスを、OK なら null を返す（呼び出し側はそのまま処理を続ける）。
+ *
+ * 利用者の ts_session（Cookie）とは別系統。一般ユーザーは admin API に到達できない（権限分離）。
+ *
+ * 注: `_` プレフィックスのため Next.js のルーティング対象にはならない（route.ts のみが対象）。
+ */
+export async function requireAdmin(req: NextRequest): Promise<NextResponse | null> {
+  const result = await validateAuthHeader(req.headers.get("authorization"))
+  if (!result.valid) {
+    return NextResponse.json({ success: false, error: result.error ?? "認証が必要です" }, { status: 401 })
+  }
+  return null
+}

--- a/my-app/app/api/web/team-schedules/admin/discord-bans/[discordUserId]/route.ts
+++ b/my-app/app/api/web/team-schedules/admin/discord-bans/[discordUserId]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server"
+import { removeDiscordBan } from "@/app/_domains/teamSchedules/_server/bans"
+import { requireAdmin } from "../../_auth"
+
+type RouteContext = { params: Promise<{ discordUserId: string }> }
+
+/**
+ * DELETE /api/web/team-schedules/admin/discord-bans/[discordUserId]
+ * Discord ID の BAN を解除する（要 admin）。解除後は magic-link での新規ログインが再び可能になる。
+ */
+export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  const unauthorized = await requireAdmin(req)
+  if (unauthorized) return unauthorized
+
+  try {
+    const { discordUserId } = await ctx.params
+    // POST 側の追加バリデーションと揃える（不正フォーマットは DB に当てず 400）
+    if (!/^\d{15,21}$/.test(discordUserId)) {
+      return NextResponse.json({ success: false, error: "Discord ID が不正です" }, { status: 400 })
+    }
+    const removed = await removeDiscordBan(discordUserId)
+    if (!removed) {
+      return NextResponse.json({ success: false, error: "対象の BAN が見つかりません" }, { status: 404 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("team-schedules admin discord-bans DELETE error:", error)
+    return NextResponse.json({ success: false, error: "BAN の解除に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/admin/discord-bans/route.test.ts
+++ b/my-app/app/api/web/team-schedules/admin/discord-bans/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { GET, POST } from "./route"
+import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
+
+// 管理API認証をモック（admin 認証の成否で 401/処理続行を切り替える）
+const mockValidateAuthHeader = vi.fn()
+vi.mock("@/app/_server/lib/auth", () => ({
+  validateAuthHeader: (...args: unknown[]) => mockValidateAuthHeader(...args),
+}))
+
+// bans ドメインロジックはモック（DB を引かない）
+const mockListDiscordBans = vi.fn()
+const mockAddDiscordBan = vi.fn()
+vi.mock("@/app/_domains/teamSchedules/_server/bans", () => ({
+  listDiscordBans: (...args: unknown[]) => mockListDiscordBans(...args),
+  addDiscordBan: (...args: unknown[]) => mockAddDiscordBan(...args),
+}))
+
+const URL = "http://localhost:3000/api/web/team-schedules/admin/discord-bans"
+const BANNED_AT = new Date("2026-06-20T00:00:00.000Z")
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockValidateAuthHeader.mockResolvedValue({ valid: true })
+  mockListDiscordBans.mockResolvedValue([{ discordUserId: "123456789012345678", reason: "spam", bannedAt: BANNED_AT }])
+  mockAddDiscordBan.mockResolvedValue({ discordUserId: "123456789012345678", reason: "spam", bannedAt: BANNED_AT })
+})
+
+describe("GET /team-schedules/admin/discord-bans", () => {
+  it("failure: admin 認証が無ければ401（権限分離・一覧を引かない）", async () => {
+    mockValidateAuthHeader.mockResolvedValue({ valid: false, error: "認証ヘッダーが必要です" })
+    const res = await GET(createTestRequest(URL))
+    expect(res.status).toBe(401)
+    expect(mockListDiscordBans).not.toHaveBeenCalled()
+  })
+
+  it("success: admin なら BAN 一覧を ISO 文字列で返す", async () => {
+    const res = await GET(createTestRequest(URL, { headers: { authorization: "Bearer x" } }))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.bans).toEqual([{ discordUserId: "123456789012345678", reason: "spam", bannedAt: BANNED_AT.toISOString() }])
+  })
+})
+
+describe("POST /team-schedules/admin/discord-bans", () => {
+  it("failure: admin 認証が無ければ401（追加しない）", async () => {
+    mockValidateAuthHeader.mockResolvedValue({ valid: false, error: "認証ヘッダーが必要です" })
+    const res = await POST(createTestRequest(URL, { method: "POST", body: { discordUserId: "123456789012345678" } }))
+    expect(res.status).toBe(401)
+    expect(mockAddDiscordBan).not.toHaveBeenCalled()
+  })
+
+  it("failure: 不正な Discord ID（数字以外）は400（追加しない）", async () => {
+    const res = await POST(createTestRequest(URL, { method: "POST", body: { discordUserId: "not-a-snowflake" } }))
+    expect(res.status).toBe(400)
+    expect(mockAddDiscordBan).not.toHaveBeenCalled()
+  })
+
+  it("success: admin なら BAN を追加し、理由は trim される", async () => {
+    const res = await POST(createTestRequest(URL, { method: "POST", body: { discordUserId: "123456789012345678", reason: "  spam  " } }))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(mockAddDiscordBan).toHaveBeenCalledWith("123456789012345678", "spam")
+    expect(json.ban).toEqual({ discordUserId: "123456789012345678", reason: "spam", bannedAt: BANNED_AT.toISOString() })
+  })
+
+  it("success: 理由が空文字なら null として追加する", async () => {
+    await POST(createTestRequest(URL, { method: "POST", body: { discordUserId: "123456789012345678", reason: "   " } }))
+    expect(mockAddDiscordBan).toHaveBeenCalledWith("123456789012345678", null)
+  })
+})

--- a/my-app/app/api/web/team-schedules/admin/discord-bans/route.ts
+++ b/my-app/app/api/web/team-schedules/admin/discord-bans/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server"
+import { addDiscordBan, listDiscordBans } from "@/app/_domains/teamSchedules/_server/bans"
+import type { AdminDiscordBan } from "@/app/_domains/teamSchedules/types"
+import { requireAdmin } from "../_auth"
+
+/** Discord snowflake（数字のみ・17〜20桁が一般的）。経路バリデーション用に少し緩めに見る */
+const isDiscordId = (value: unknown): value is string => typeof value === "string" && /^\d{15,21}$/.test(value)
+const REASON_MAX_LENGTH = 500
+
+/**
+ * GET /api/web/team-schedules/admin/discord-bans
+ * BAN 済み Discord ID の一覧を返す（要 admin・新しい順）。
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const unauthorized = await requireAdmin(req)
+  if (unauthorized) return unauthorized
+
+  try {
+    const rows = await listDiscordBans()
+    const bans: AdminDiscordBan[] = rows.map((b) => ({ discordUserId: b.discordUserId, reason: b.reason, bannedAt: b.bannedAt.toISOString() }))
+    return NextResponse.json({ success: true, bans })
+  } catch (error) {
+    console.error("team-schedules admin discord-bans GET error:", error)
+    return NextResponse.json({ success: false, error: "BAN 一覧の取得に失敗しました" }, { status: 500 })
+  }
+}
+
+/**
+ * POST /api/web/team-schedules/admin/discord-bans
+ * Discord ID を BAN に追加する（要 admin）。body: { discordUserId, reason? }
+ *
+ * ↓注意: BAN は auth/verify（新規ログイン）でのみ判定する。既に ts_session を持つユーザーは
+ *        最大30日のセッションが残るため即時ログアウトされない（利用者側の即時失効は将来対応）。
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const unauthorized = await requireAdmin(req)
+  if (unauthorized) return unauthorized
+
+  try {
+    const body = (await req.json().catch(() => null)) as { discordUserId?: unknown; reason?: unknown } | null
+    if (!body || !isDiscordId(body.discordUserId)) {
+      return NextResponse.json({ success: false, error: "Discord ID（数字のみ）を入力してください" }, { status: 400 })
+    }
+    if (body.reason !== undefined && body.reason !== null && (typeof body.reason !== "string" || body.reason.length > REASON_MAX_LENGTH)) {
+      return NextResponse.json({ success: false, error: "理由は500文字以内で入力してください" }, { status: 400 })
+    }
+    const reason = typeof body.reason === "string" && body.reason.trim() !== "" ? body.reason.trim() : null
+
+    const ban = await addDiscordBan(body.discordUserId, reason)
+    const result: AdminDiscordBan = { discordUserId: ban.discordUserId, reason: ban.reason, bannedAt: ban.bannedAt.toISOString() }
+    return NextResponse.json({ success: true, ban: result })
+  } catch (error) {
+    console.error("team-schedules admin discord-bans POST error:", error)
+    return NextResponse.json({ success: false, error: "BAN の追加に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/admin/overview/route.ts
+++ b/my-app/app/api/web/team-schedules/admin/overview/route.ts
@@ -1,0 +1,109 @@
+import { desc, eq, notInArray } from "drizzle-orm"
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/app/_server/lib/db"
+import { discordLinks, teamMembers, teams, users } from "@/app/_domains/teamSchedules/_server/schema"
+import type { AdminOrphanUser, AdminOverview, AdminTeam, AdminTeamMember, LolRoleFlags } from "@/app/_domains/teamSchedules/types"
+import { requireAdmin } from "../_auth"
+
+/**
+ * GET /api/web/team-schedules/admin/overview
+ * 全チーム＋設定＋メンバー（discordUserId, teamRole, suspended 含む）＋無所属ユーザーを返す（要 admin）。
+ *
+ * 管理画面のメイン取得。admin 認証済みのため Discord ID を含めてよい（利用者APIとは別方針）。
+ * neon-http は逐次クエリ。件数は運用規模（数十〜数百）を想定し、JS 側でグルーピングする。
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const unauthorized = await requireAdmin(req)
+  if (unauthorized) return unauthorized
+
+  try {
+    // 全チーム（作成日時の新しい順）
+    const teamRows = await db
+      .select({
+        teamId: teams.teamId,
+        name: teams.name,
+        description: teams.description,
+        requiredCount: teams.requiredCount,
+        managementMode: teams.managementMode,
+        createdAt: teams.createdAt,
+      })
+      .from(teams)
+      .orderBy(desc(teams.createdAt))
+
+    // 全メンバー（所属ユーザーの suspended も join で取得）
+    const memberRows = await db
+      .select({
+        teamId: teamMembers.teamId,
+        userId: teamMembers.userId,
+        displayName: users.displayName,
+        teamRole: teamMembers.teamRole,
+        suspended: users.suspended,
+        top: teamMembers.top,
+        jungle: teamMembers.jungle,
+        mid: teamMembers.mid,
+        adc: teamMembers.adc,
+        support: teamMembers.support,
+      })
+      .from(teamMembers)
+      .innerJoin(users, eq(users.userId, teamMembers.userId))
+
+    // userId → 紐づく Discord ID（複数可）のマップを作る
+    const linkRows = await db.select({ userId: discordLinks.userId, discordUserId: discordLinks.discordUserId }).from(discordLinks)
+    const discordIdsByUser = new Map<string, string[]>()
+    for (const l of linkRows) {
+      const list = discordIdsByUser.get(l.userId) ?? []
+      list.push(l.discordUserId)
+      discordIdsByUser.set(l.userId, list)
+    }
+
+    // teamId → メンバー配列
+    const membersByTeam = new Map<string, AdminTeamMember[]>()
+    for (const m of memberRows) {
+      const roles: LolRoleFlags = { top: m.top, jungle: m.jungle, mid: m.mid, adc: m.adc, support: m.support }
+      const member: AdminTeamMember = {
+        userId: m.userId,
+        displayName: m.displayName,
+        teamRole: m.teamRole,
+        suspended: m.suspended,
+        discordUserIds: discordIdsByUser.get(m.userId) ?? [],
+        roles,
+      }
+      const list = membersByTeam.get(m.teamId) ?? []
+      list.push(member)
+      membersByTeam.set(m.teamId, list)
+    }
+
+    const teamList: AdminTeam[] = teamRows.map((t) => ({
+      teamId: t.teamId,
+      name: t.name,
+      description: t.description,
+      requiredCount: t.requiredCount,
+      managementMode: t.managementMode,
+      createdAt: t.createdAt.toISOString(),
+      members: membersByTeam.get(t.teamId) ?? [],
+    }))
+
+    // 無所属ユーザー（team_members に1行も無いユーザー）。
+    // どのチームにも属していない userId の集合を team_members から除外して取得する。
+    const memberUserIds = [...new Set(memberRows.map((m) => m.userId))]
+    const orphanRows = await db
+      .select({ userId: users.userId, displayName: users.displayName, suspended: users.suspended, createdAt: users.createdAt })
+      .from(users)
+      .where(memberUserIds.length > 0 ? notInArray(users.userId, memberUserIds) : undefined)
+      .orderBy(desc(users.createdAt))
+
+    const orphanUsers: AdminOrphanUser[] = orphanRows.map((u) => ({
+      userId: u.userId,
+      displayName: u.displayName,
+      suspended: u.suspended,
+      discordUserIds: discordIdsByUser.get(u.userId) ?? [],
+      createdAt: u.createdAt.toISOString(),
+    }))
+
+    const result: AdminOverview = { teams: teamList, orphanUsers }
+    return NextResponse.json({ success: true, ...result })
+  } catch (error) {
+    console.error("team-schedules admin overview GET error:", error)
+    return NextResponse.json({ success: false, error: "管理データの取得に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/admin/teams/[teamId]/members/[userId]/route.ts
+++ b/my-app/app/api/web/team-schedules/admin/teams/[teamId]/members/[userId]/route.ts
@@ -1,0 +1,51 @@
+import { and, eq } from "drizzle-orm"
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/app/_server/lib/db"
+import { teamMembers } from "@/app/_domains/teamSchedules/_server/schema"
+import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
+import { requireAdmin } from "../../../../_auth"
+
+type RouteContext = { params: Promise<{ teamId: string; userId: string }> }
+
+/**
+ * DELETE /api/web/team-schedules/admin/teams/[teamId]/members/[userId]
+ * 指定メンバーをチームから除外する（要 admin）。team_members 行を1件削除し、
+ * 複合FK の cascade でそのチーム内のそのユーザーの schedules も消える。
+ *
+ * 割り切り: master の除外はブロックする（master 不在の孤児チームを作らないため）。
+ * master を外したいときはチーム強制解散、または別途 master 移譲後に除外する。
+ */
+export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  const unauthorized = await requireAdmin(req)
+  if (unauthorized) return unauthorized
+
+  try {
+    const { teamId, userId } = await ctx.params
+    if (!isUuid(teamId) || !isUuid(userId)) {
+      return NextResponse.json({ success: false, error: "IDが不正です" }, { status: 400 })
+    }
+
+    const rows = await db
+      .select({ teamRole: teamMembers.teamRole })
+      .from(teamMembers)
+      .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)))
+      .limit(1)
+    const member = rows[0]
+    if (!member) {
+      return NextResponse.json({ success: false, error: "対象のメンバーが見つかりません" }, { status: 404 })
+    }
+    if (member.teamRole === "master") {
+      return NextResponse.json(
+        { success: false, error: "管理者（master）は除外できません。チームを強制解散するか、先に master を別メンバーへ移譲してください。" },
+        { status: 400 },
+      )
+    }
+
+    await db.delete(teamMembers).where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)))
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("team-schedules admin member DELETE error:", error)
+    return NextResponse.json({ success: false, error: "メンバーの除外に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/admin/teams/[teamId]/route.ts
+++ b/my-app/app/api/web/team-schedules/admin/teams/[teamId]/route.ts
@@ -1,0 +1,37 @@
+import { eq } from "drizzle-orm"
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/app/_server/lib/db"
+import { teams } from "@/app/_domains/teamSchedules/_server/schema"
+import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
+import { requireAdmin } from "../../_auth"
+
+type RouteContext = { params: Promise<{ teamId: string }> }
+
+/**
+ * DELETE /api/web/team-schedules/admin/teams/[teamId]
+ * チームを強制解散する（要 admin）。team メンバーシップに依らないスーパーユーザー操作のため role チェック無し。
+ *
+ * teams 行を1件削除すると FK の onDelete 連鎖で関連データがまとめて消える
+ * （team_members → schedules / team_day_status）。取り消し不可。
+ */
+export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  const unauthorized = await requireAdmin(req)
+  if (unauthorized) return unauthorized
+
+  try {
+    const { teamId } = await ctx.params
+    if (!isUuid(teamId)) {
+      return NextResponse.json({ success: false, error: "チームIDが不正です" }, { status: 400 })
+    }
+
+    const deleted = await db.delete(teams).where(eq(teams.teamId, teamId)).returning({ teamId: teams.teamId })
+    if (deleted.length === 0) {
+      return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("team-schedules admin team DELETE error:", error)
+    return NextResponse.json({ success: false, error: "チームの解散に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/admin/users/[userId]/route.ts
+++ b/my-app/app/api/web/team-schedules/admin/users/[userId]/route.ts
@@ -1,0 +1,40 @@
+import { eq } from "drizzle-orm"
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/app/_server/lib/db"
+import { users } from "@/app/_domains/teamSchedules/_server/schema"
+import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
+import { requireAdmin } from "../../_auth"
+
+type RouteContext = { params: Promise<{ userId: string }> }
+
+/**
+ * DELETE /api/web/team-schedules/admin/users/[userId]
+ * ユーザーアカウントを完全削除する（要 admin）。users 行を1件削除すると FK の onDelete 連鎖で
+ * 関連データがまとめて消える（team_members → schedules / discord_links）。取り消し不可。
+ *
+ * 割り切り（#166）: 削除対象が master を務めるチームは「自動解散しない」。
+ * cascade で当該ユーザーの team_members 行だけ消え、チーム自体は master 不在のまま残る。
+ * その孤児チームは管理画面で警告し、別途手動で強制解散する想定（利用者側の account 削除が
+ * master 不在を 403 で防ぐのとは別方針＝admin はスーパーユーザーなので止めない）。
+ */
+export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  const unauthorized = await requireAdmin(req)
+  if (unauthorized) return unauthorized
+
+  try {
+    const { userId } = await ctx.params
+    if (!isUuid(userId)) {
+      return NextResponse.json({ success: false, error: "ユーザーIDが不正です" }, { status: 400 })
+    }
+
+    const deleted = await db.delete(users).where(eq(users.userId, userId)).returning({ userId: users.userId })
+    if (deleted.length === 0) {
+      return NextResponse.json({ success: false, error: "ユーザーが見つかりません" }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("team-schedules admin user DELETE error:", error)
+    return NextResponse.json({ success: false, error: "ユーザーの削除に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/admin/users/[userId]/suspend/route.test.ts
+++ b/my-app/app/api/web/team-schedules/admin/users/[userId]/suspend/route.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { POST, DELETE } from "./route"
+import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
+
+// 管理API認証をモック
+const mockValidateAuthHeader = vi.fn()
+vi.mock("@/app/_server/lib/auth", () => ({
+  validateAuthHeader: (...args: unknown[]) => mockValidateAuthHeader(...args),
+}))
+
+// DB: db.update(users).set({ suspended }).where().returning() → 更新行
+const updateReturning = vi.fn(async () => [{ userId: "user-1" }])
+const updateWhere = vi.fn(() => ({ returning: updateReturning }))
+const updateSet = vi.fn(() => ({ where: updateWhere }))
+const update = vi.fn((..._a: unknown[]) => ({ set: updateSet }))
+vi.mock("@/app/_server/lib/db", () => ({
+  db: { update: (...args: unknown[]) => update(...args) },
+}))
+
+const USER_ID = "123e4567-e89b-42d3-a456-426614174000"
+const URL = `http://localhost:3000/api/web/team-schedules/admin/users/${USER_ID}/suspend`
+const ctxFor = (userId: string = USER_ID) => ({ params: Promise.resolve({ userId }) })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockValidateAuthHeader.mockResolvedValue({ valid: true })
+  updateReturning.mockResolvedValue([{ userId: "user-1" }])
+})
+
+describe("POST /admin/users/[userId]/suspend", () => {
+  it("failure: admin 認証が無ければ401（更新しない）", async () => {
+    mockValidateAuthHeader.mockResolvedValue({ valid: false, error: "認証ヘッダーが必要です" })
+    const res = await POST(createTestRequest(URL, { method: "POST" }), ctxFor())
+    expect(res.status).toBe(401)
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it("failure: 不正な userId（非UUID）は400", async () => {
+    const res = await POST(createTestRequest(URL, { method: "POST" }), ctxFor("own"))
+    expect(res.status).toBe(400)
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it("failure: 対象ユーザーが存在しなければ404", async () => {
+    updateReturning.mockResolvedValue([])
+    const res = await POST(createTestRequest(URL, { method: "POST" }), ctxFor())
+    expect(res.status).toBe(404)
+  })
+
+  it("success: suspended=true に更新する", async () => {
+    const res = await POST(createTestRequest(URL, { method: "POST" }), ctxFor())
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.suspended).toBe(true)
+    expect(updateSet).toHaveBeenCalledWith({ suspended: true })
+  })
+})
+
+describe("DELETE /admin/users/[userId]/suspend", () => {
+  it("success: suspended=false に更新する（解除）", async () => {
+    const res = await DELETE(createTestRequest(URL, { method: "DELETE" }), ctxFor())
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.suspended).toBe(false)
+    expect(updateSet).toHaveBeenCalledWith({ suspended: false })
+  })
+})

--- a/my-app/app/api/web/team-schedules/admin/users/[userId]/suspend/route.ts
+++ b/my-app/app/api/web/team-schedules/admin/users/[userId]/suspend/route.ts
@@ -1,0 +1,44 @@
+import { eq } from "drizzle-orm"
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/app/_server/lib/db"
+import { users } from "@/app/_domains/teamSchedules/_server/schema"
+import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
+import { requireAdmin } from "../../../_auth"
+
+type RouteContext = { params: Promise<{ userId: string }> }
+
+/**
+ * users.suspended を指定値に更新する共通処理（要 admin）。
+ * POST=利用停止 / DELETE=解除。書き込み系 API が suspended=true の間 403 を返す（読み取りは透過）。
+ */
+async function setSuspended(req: NextRequest, ctx: RouteContext, suspended: boolean): Promise<NextResponse> {
+  const unauthorized = await requireAdmin(req)
+  if (unauthorized) return unauthorized
+
+  try {
+    const { userId } = await ctx.params
+    if (!isUuid(userId)) {
+      return NextResponse.json({ success: false, error: "ユーザーIDが不正です" }, { status: 400 })
+    }
+
+    const updated = await db.update(users).set({ suspended }).where(eq(users.userId, userId)).returning({ userId: users.userId })
+    if (updated.length === 0) {
+      return NextResponse.json({ success: false, error: "ユーザーが見つかりません" }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true, suspended })
+  } catch (error) {
+    console.error("team-schedules admin suspend error:", error)
+    return NextResponse.json({ success: false, error: "利用停止状態の更新に失敗しました" }, { status: 500 })
+  }
+}
+
+/** POST /api/web/team-schedules/admin/users/[userId]/suspend — 利用停止にする */
+export async function POST(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  return setSuspended(req, ctx, true)
+}
+
+/** DELETE /api/web/team-schedules/admin/users/[userId]/suspend — 利用停止を解除する */
+export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  return setSuspended(req, ctx, false)
+}

--- a/my-app/app/api/web/team-schedules/auth/verify/route.test.ts
+++ b/my-app/app/api/web/team-schedules/auth/verify/route.test.ts
@@ -21,12 +21,20 @@ vi.mock("@/app/_server/lib/db", () => ({
   },
 }))
 
+// BAN 判定はモック（デフォルトは未 BAN）。実 DB を引かないよう bans モジュールごと差し替える
+const mockIsDiscordBanned = vi.fn()
+vi.mock("@/app/_domains/teamSchedules/_server/bans", () => ({
+  isDiscordBanned: (...a: unknown[]) => mockIsDiscordBanned(...a),
+}))
+
 const URL = "http://localhost:3000/api/web/team-schedules/auth/verify"
 
 beforeEach(() => {
   vi.clearAllMocks()
   // 既存 discord_links 検索は「無し」を返す（→ セルフサインアップ経路）
   selectLimit.mockResolvedValue([])
+  // デフォルトは未 BAN（個別テストで上書き）
+  mockIsDiscordBanned.mockResolvedValue(false)
 })
 
 describe("POST /team-schedules/auth/verify", () => {
@@ -53,6 +61,18 @@ describe("POST /team-schedules/auth/verify", () => {
     expect(res.cookies.get("ts_session")?.value).toBeTruthy()
     // users / discord_links の2回 INSERT
     expect(insert).toHaveBeenCalledTimes(2)
+  })
+
+  it("failure: BAN 済み Discord ID は403（ユーザー作成・Cookie設定をしない）", async () => {
+    const token = "banned-token"
+    await redisSet(magicLinkKey(token), { discordUserId: "banned-discord", username: "荒らし" }, 600)
+    mockIsDiscordBanned.mockResolvedValue(true)
+
+    const res = await POST(createTestRequest(URL, { method: "POST", body: { token } }))
+    expect(res.status).toBe(403)
+    // ユーザー作成はしない / セッションCookieも設定しない
+    expect(insert).not.toHaveBeenCalled()
+    expect(res.cookies.get("ts_session")?.value).toBeFalsy()
   })
 
   it("failure: 一度使ったtokenは単回使用で消費され、2回目は401", async () => {

--- a/my-app/app/api/web/team-schedules/auth/verify/route.ts
+++ b/my-app/app/api/web/team-schedules/auth/verify/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { magicLinkKey } from "@/app/_domains/teamSchedules/_server/redisKeys"
 import { createUserSession, sessionCookieOptions, TS_SESSION_COOKIE } from "@/app/_domains/teamSchedules/_server/session"
 import { canCreateTeam } from "@/app/_domains/teamSchedules/_server/authz"
+import { isDiscordBanned } from "@/app/_domains/teamSchedules/_server/bans"
 import { resolveOrCreateUserByDiscordId } from "@/app/_domains/teamSchedules/_server/userResolver"
 import { redisGet, redisDelete } from "@/app/_server/lib/redis/redis"
 import type { MagicLinkPayload } from "@/app/api/discord/command/team-schedule/login"
@@ -36,6 +37,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     await redisDelete(magicLinkKey(token))
 
     const { discordUserId, username } = payload
+
+    // BAN 済み Discord ID は新規ログイン/サインアップを遮断（#166）。
+    // ↓注意: 既に ts_session を持つユーザーの即時失効はここでは行わない（将来対応）。
+    if (await isDiscordBanned(discordUserId)) {
+      console.warn(`team-schedules auth/verify: banned discord id rejected token=${tokenPrefix}…`)
+      return NextResponse.json({ success: false, error: "このアカウントはご利用いただけません" }, { status: 403 })
+    }
 
     // discord_links を引いて既存ユーザーを解決。無ければセルフサインアップで作成
     const { userId, displayName } = await resolveOrCreateUserByDiscordId(discordUserId, username)

--- a/my-app/app/api/web/team-schedules/join/route.test.ts
+++ b/my-app/app/api/web/team-schedules/join/route.test.ts
@@ -6,8 +6,10 @@ import { inviteKey } from "@/app/_domains/teamSchedules/_server/redisKeys"
 
 // 認可ヘルパーをモック
 const mockGetSessionUserId = vi.fn()
+const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
+  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
 }))
 
 // DB は実接続しない。
@@ -34,6 +36,7 @@ const TOKEN = "invite-token-abc"
 beforeEach(() => {
   vi.clearAllMocks()
   selectLimit.mockResolvedValue([TEAM])
+  mockIsUserSuspended.mockResolvedValue(false)
 })
 
 describe("POST /team-schedules/join", () => {
@@ -42,6 +45,15 @@ describe("POST /team-schedules/join", () => {
     await redisSet(inviteKey(TOKEN), { teamId: TEAM.teamId }, 600)
     const res = await POST(createTestRequest(URL, { method: "POST", body: { token: TOKEN } }))
     expect(res.status).toBe(401)
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("failure: 利用停止中ユーザーは403（参加しない）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    mockIsUserSuspended.mockResolvedValue(true)
+    await redisSet(inviteKey(TOKEN), { teamId: TEAM.teamId }, 600)
+    const res = await POST(createTestRequest(URL, { method: "POST", body: { token: TOKEN } }))
+    expect(res.status).toBe(403)
     expect(insert).not.toHaveBeenCalled()
   })
 

--- a/my-app/app/api/web/team-schedules/join/route.ts
+++ b/my-app/app/api/web/team-schedules/join/route.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teamMembers, teams } from "@/app/_domains/teamSchedules/_server/schema"
-import { getSessionUserId } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
 import { inviteKey } from "@/app/_domains/teamSchedules/_server/redisKeys"
 import type { InvitePayload } from "@/app/_domains/teamSchedules/_server/invites"
 import { redisGet } from "@/app/_server/lib/redis/redis"
@@ -21,6 +21,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const userId = await getSessionUserId(req)
     if (!userId) {
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    // 利用停止中ユーザーは書き込み不可（#166）
+    if (await isUserSuspended(userId)) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
 
     const body = (await req.json().catch(() => null)) as { token?: unknown } | null

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.test.ts
@@ -6,9 +6,11 @@ import { redisSet } from "@/app/_server/lib/redis/redis"
 // 認可ヘルパーをモック（未ログイン401・非admin404・admin200 のロジックを route 単体で検証する）
 const mockGetSessionUserId = vi.fn()
 const mockAssertTeamAdmin = vi.fn()
+const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
   assertTeamAdmin: (...args: unknown[]) => mockAssertTeamAdmin(...args),
+  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
 }))
 
 const TEAM_ID = "123e4567-e89b-42d3-a456-426614174000"
@@ -17,6 +19,7 @@ const ctxFor = (teamId: string = TEAM_ID) => ({ params: Promise.resolve({ teamId
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockIsUserSuspended.mockResolvedValue(false)
 })
 
 describe("POST /team-schedules/teams/[teamId]/invite", () => {
@@ -31,6 +34,14 @@ describe("POST /team-schedules/teams/[teamId]/invite", () => {
     mockGetSessionUserId.mockResolvedValue(null)
     const res = await POST(createTestRequest(URL, { method: "POST" }), ctxFor())
     expect(res.status).toBe(401)
+    expect(redisSet).not.toHaveBeenCalled()
+  })
+
+  it("failure: 利用停止中ユーザーは403（招待を発行しない）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    mockIsUserSuspended.mockResolvedValue(true)
+    const res = await POST(createTestRequest(URL, { method: "POST" }), ctxFor())
+    expect(res.status).toBe(403)
     expect(redisSet).not.toHaveBeenCalled()
   })
 

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.test.ts
@@ -3,14 +3,19 @@ import { POST } from "./route"
 import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
 import { redisSet } from "@/app/_server/lib/redis/redis"
 
-// 認可ヘルパーをモック（未ログイン401・非admin404・admin200 のロジックを route 単体で検証する）
+// 認可ヘルパーをモック（未ログイン401・非admin404・admin200 のロジックを route 単体で検証する）。
+// route は suspend 判定とロール取得を getTeamMembershipWithSuspension の1クエリに畳んでいるため、
+// 従来の「suspended」「admin か否か」を別々に与えられるよう2つの粒度モックから合成する
+// （admin 判定は hasAdminAuthority に通す前提で teamRole を admin/null に振り分ける）。
 const mockGetSessionUserId = vi.fn()
 const mockAssertTeamAdmin = vi.fn()
 const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
-  assertTeamAdmin: (...args: unknown[]) => mockAssertTeamAdmin(...args),
-  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
+  getTeamMembershipWithSuspension: async (...args: unknown[]) => ({
+    suspended: await mockIsUserSuspended(...args),
+    teamRole: (await mockAssertTeamAdmin(...args)) ? "admin" : null,
+  }),
 }))
 
 const TEAM_ID = "123e4567-e89b-42d3-a456-426614174000"

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server"
-import { assertTeamAdmin, getSessionUserId } from "@/app/_domains/teamSchedules/_server/authz"
+import { assertTeamAdmin, getSessionUserId, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
 import { createInviteToken, INVITE_TTL } from "@/app/_domains/teamSchedules/_server/invites"
 import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
 import { APP_URL } from "@/app/_server/lib/env"
@@ -21,6 +21,11 @@ export async function POST(req: NextRequest, ctx: RouteContext): Promise<NextRes
     const userId = await getSessionUserId(req)
     if (!userId) {
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    // 利用停止中ユーザーは書き込み不可（#166）
+    if (await isUserSuspended(userId)) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
 
     // admin でなければ存在を隠して 404

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/invite/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
-import { assertTeamAdmin, getSessionUserId, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, getTeamMembershipWithSuspension } from "@/app/_domains/teamSchedules/_server/authz"
+import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
 import { createInviteToken, INVITE_TTL } from "@/app/_domains/teamSchedules/_server/invites"
 import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
 import { APP_URL } from "@/app/_server/lib/env"
@@ -23,14 +24,14 @@ export async function POST(req: NextRequest, ctx: RouteContext): Promise<NextRes
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
     }
 
-    // 利用停止中ユーザーは書き込み不可（#166）
-    if (await isUserSuspended(userId)) {
+    // 利用停止判定とロール取得を1クエリにまとめる（#166・DB往復削減）。suspend→403 を先に判定する
+    const { suspended, teamRole } = await getTeamMembershipWithSuspension(teamId, userId)
+    if (suspended) {
       return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
 
-    // admin でなければ存在を隠して 404
-    const isAdmin = await assertTeamAdmin(teamId, userId)
-    if (!isAdmin) {
+    // admin（master/admin）でなければ存在を隠して 404（非メンバーもロール不足も同じ扱い）
+    if (teamRole === null || !hasAdminAuthority(teamRole)) {
       return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
     }
 

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/membership/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/membership/route.ts
@@ -16,6 +16,11 @@ type RouteContext = { params: Promise<{ teamId: string }> }
  * - それ以外のメンバー（admin / member）: 自分の行を削除して 200
  *
  * 注: チームそのものの削除ではない（DELETE /teams/[teamId] とは別操作）。
+ *
+ * #166: 利用停止中（suspended）でも脱退は許可する（isUserSuspended ガードを意図的に付けない）。
+ *       suspend は「新しいコンテンツ・参加を作らせない」ための制限で、自分の footprint を減らす
+ *       自己片付け（脱退・アカウント削除）は止めない方針。チーム設定編集/解散（PATCH/DELETE teams）は
+ *       コンテンツ書き込みなのでガード対象、という非対称を明示しておく。
  */
 export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
   try {

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/route.test.ts
@@ -2,14 +2,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { PATCH } from "./route"
 import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
 
-// 認可ヘルパーをモック（非メンバー404・非admin400・admin200 のロジックを route 単体で検証する）
+// 認可ヘルパーをモック（非メンバー404・非admin400・admin200 のロジックを route 単体で検証する）。
+// route は suspend 判定とロール取得を getTeamMembershipWithSuspension の1クエリに畳んでいるため、
+// テストは従来どおり「suspended」「teamRole」を別々に与えられるよう、2つの粒度モックから合成する。
 const mockGetSessionUserId = vi.fn()
 const mockGetTeamRole = vi.fn()
 const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
-  getTeamRole: (...args: unknown[]) => mockGetTeamRole(...args),
-  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
+  getTeamMembershipWithSuspension: async (...args: unknown[]) => ({
+    suspended: await mockIsUserSuspended(...args),
+    teamRole: await mockGetTeamRole(...args),
+  }),
 }))
 
 // DB は実接続しない。update が呼ばれたかと、返却用の re-select だけ確認する

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/route.test.ts
@@ -5,9 +5,11 @@ import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
 // 認可ヘルパーをモック（非メンバー404・非admin400・admin200 のロジックを route 単体で検証する）
 const mockGetSessionUserId = vi.fn()
 const mockGetTeamRole = vi.fn()
+const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
   getTeamRole: (...args: unknown[]) => mockGetTeamRole(...args),
+  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
 }))
 
 // DB は実接続しない。update が呼ばれたかと、返却用の re-select だけ確認する
@@ -34,6 +36,7 @@ const ctxFor = () => ({ params: Promise.resolve({ teamId: TEAM_ID }) })
 beforeEach(() => {
   vi.clearAllMocks()
   selectLimit.mockResolvedValue([{ ...TEAM_ROW, teamId: TEAM_ID }])
+  mockIsUserSuspended.mockResolvedValue(false)
 })
 
 describe("PATCH /team-schedules/teams/[teamId]", () => {
@@ -42,6 +45,15 @@ describe("PATCH /team-schedules/teams/[teamId]", () => {
     const req = createTestRequest(URL, { method: "PATCH", body: { managementMode: "team" } })
     const res = await PATCH(req, ctxFor())
     expect(res.status).toBe(401)
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it("failure: 利用停止中ユーザーは403（更新もしない）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    mockIsUserSuspended.mockResolvedValue(true)
+    const req = createTestRequest(URL, { method: "PATCH", body: { managementMode: "team" } })
+    const res = await PATCH(req, ctxFor())
+    expect(res.status).toBe(403)
     expect(update).not.toHaveBeenCalled()
   })
 

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/route.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teams } from "@/app/_domains/teamSchedules/_server/schema"
-import { getSessionUserId, getTeamRole, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, getTeamMembershipWithSuspension } from "@/app/_domains/teamSchedules/_server/authz"
 import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
 import { isManagementMode, isUuid, isValidRequiredCount, isValidTeamName } from "@/app/_domains/teamSchedules/_server/validators"
 import type { TeamManagementMode, TeamSummary } from "@/app/_domains/teamSchedules/types"
@@ -29,12 +29,11 @@ async function authorizeTeamAdmin(req: NextRequest, teamId: string): Promise<Aut
     return { ok: false, res: NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 }) }
   }
 
-  // 利用停止中ユーザーは書き込み不可（#166）。ログイン確認の直後に判定する
-  if (await isUserSuspended(userId)) {
+  // 利用停止判定とロール取得を1クエリにまとめる（#166・DB往復削減）。suspend→403 を先に判定する
+  const { suspended, teamRole: role } = await getTeamMembershipWithSuspension(teamId, userId)
+  if (suspended) {
     return { ok: false, res: NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 }) }
   }
-
-  const role = await getTeamRole(teamId, userId)
   if (role === null) {
     return { ok: false, res: NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 }) }
   }
@@ -156,12 +155,11 @@ export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextR
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
     }
 
-    // 利用停止中ユーザーは書き込み不可（#166）
-    if (await isUserSuspended(userId)) {
+    // 利用停止判定とロール取得を1クエリにまとめる（#166・DB往復削減）。suspend→403 を先に判定する
+    const { suspended, teamRole: role } = await getTeamMembershipWithSuspension(teamId, userId)
+    if (suspended) {
       return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
-
-    const role = await getTeamRole(teamId, userId)
     if (role === null) {
       // 非メンバー（または削除済みチーム）は存在を隠して 404
       return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/route.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teams } from "@/app/_domains/teamSchedules/_server/schema"
-import { getSessionUserId, getTeamRole } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, getTeamRole, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
 import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
 import { isManagementMode, isUuid, isValidRequiredCount, isValidTeamName } from "@/app/_domains/teamSchedules/_server/validators"
 import type { TeamManagementMode, TeamSummary } from "@/app/_domains/teamSchedules/types"
@@ -27,6 +27,11 @@ async function authorizeTeamAdmin(req: NextRequest, teamId: string): Promise<Aut
   const userId = await getSessionUserId(req)
   if (!userId) {
     return { ok: false, res: NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 }) }
+  }
+
+  // 利用停止中ユーザーは書き込み不可（#166）。ログイン確認の直後に判定する
+  if (await isUserSuspended(userId)) {
+    return { ok: false, res: NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 }) }
   }
 
   const role = await getTeamRole(teamId, userId)
@@ -149,6 +154,11 @@ export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextR
     const userId = await getSessionUserId(req)
     if (!userId) {
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    // 利用停止中ユーザーは書き込み不可（#166）
+    if (await isUserSuspended(userId)) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
 
     const role = await getTeamRole(teamId, userId)

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.test.ts
@@ -5,9 +5,11 @@ import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
 // 認可ヘルパーをモック（本人列のみ編集可・非メンバー404 のロジックを route 単体で検証する）
 const mockGetSessionUserId = vi.fn()
 const mockAssertTeamMember = vi.fn()
+const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
   assertTeamMember: (...args: unknown[]) => mockAssertTeamMember(...args),
+  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
 }))
 
 // DB は実接続しない。書き込みが呼ばれたことだけ確認する
@@ -29,6 +31,7 @@ const ctxFor = () => ({ params: Promise.resolve({ teamId: TEAM_ID }) })
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockIsUserSuspended.mockResolvedValue(false)
 })
 
 describe("PUT /team-schedules/teams/[teamId]/schedule", () => {
@@ -46,6 +49,15 @@ describe("PUT /team-schedules/teams/[teamId]/schedule", () => {
     const req = createTestRequest(URL, { method: "PUT", body: { day: "2026-06-14", status: "ok", note: null } })
     const res = await PUT(req, ctxFor())
     expect(res.status).toBe(404)
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("failure: 利用停止中ユーザーは403（書き込みもしない）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    mockIsUserSuspended.mockResolvedValue(true)
+    const req = createTestRequest(URL, { method: "PUT", body: { day: "2026-06-14", status: "ok", note: null } })
+    const res = await PUT(req, ctxFor())
+    expect(res.status).toBe(403)
     expect(insert).not.toHaveBeenCalled()
   })
 

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.test.ts
@@ -2,14 +2,19 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { PUT, DELETE } from "./route"
 import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
 
-// 認可ヘルパーをモック（本人列のみ編集可・非メンバー404 のロジックを route 単体で検証する）
+// 認可ヘルパーをモック（本人列のみ編集可・非メンバー404 のロジックを route 単体で検証する）。
+// route は suspend 判定とメンバーシップ取得を getTeamMembershipWithSuspension の1クエリに畳んでいるため、
+// 従来の「suspended」「メンバーか否か」を別々に与えられるよう2つの粒度モックから合成する
+// （メンバー=teamRole 非null / 非メンバー=null に振り分ける。ロールの種別は schedule では使わない）。
 const mockGetSessionUserId = vi.fn()
 const mockAssertTeamMember = vi.fn()
 const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
-  assertTeamMember: (...args: unknown[]) => mockAssertTeamMember(...args),
-  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
+  getTeamMembershipWithSuspension: async (...args: unknown[]) => ({
+    suspended: await mockIsUserSuspended(...args),
+    teamRole: (await mockAssertTeamMember(...args)) ? "member" : null,
+  }),
 }))
 
 // DB は実接続しない。書き込みが呼ばれたことだけ確認する

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
@@ -2,7 +2,7 @@ import { and, between, eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { schedules, teamDayStatus, teamMembers, teams, users } from "@/app/_domains/teamSchedules/_server/schema"
-import { getSessionUserId, assertTeamMember, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, getTeamMembershipWithSuspension } from "@/app/_domains/teamSchedules/_server/authz"
 import { isDayKey, isScheduleStatus, isUuid, isValidNote } from "@/app/_domains/teamSchedules/_server/validators"
 import type { LolRoleFlags, ScheduleEntry, TeamDayStatusEntry, TeamSchedule, TeamScheduleMember } from "@/app/_domains/teamSchedules/types"
 import { ServerTiming } from "@/app/_server/lib/serverTiming"
@@ -124,8 +124,10 @@ export async function PUT(req: NextRequest, ctx: RouteContext): Promise<NextResp
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
     }
 
-    // 利用停止中ユーザーは書き込み不可（#166）
-    if (await isUserSuspended(userId)) {
+    // 利用停止判定とメンバーシップ取得を1クエリにまとめる（#166・DB往復削減）。
+    // suspend→403 は body 検証より前、メンバー判定→404 は従来どおり body 検証の後に行う
+    const { suspended, teamRole } = await getTeamMembershipWithSuspension(teamId, userId)
+    if (suspended) {
       return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
 
@@ -137,8 +139,7 @@ export async function PUT(req: NextRequest, ctx: RouteContext): Promise<NextResp
     const note = body.note ?? null
 
     // 本人がそのチームの所属（team_members に存在）でなければ、存在を隠して 404
-    const isMember = await assertTeamMember(teamId, userId)
-    if (!isMember) {
+    if (teamRole === null) {
       return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
     }
 
@@ -173,8 +174,10 @@ export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextR
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
     }
 
-    // 利用停止中ユーザーは書き込み不可（#166）
-    if (await isUserSuspended(userId)) {
+    // 利用停止判定とメンバーシップ取得を1クエリにまとめる（#166・DB往復削減）。
+    // suspend→403 は body 検証より前、メンバー判定→404 は従来どおり body 検証の後に行う
+    const { suspended, teamRole } = await getTeamMembershipWithSuspension(teamId, userId)
+    if (suspended) {
       return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
 
@@ -184,8 +187,7 @@ export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextR
     }
     const { day } = body
 
-    const isMember = await assertTeamMember(teamId, userId)
-    if (!isMember) {
+    if (teamRole === null) {
       return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
     }
 

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
@@ -2,7 +2,7 @@ import { and, between, eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { schedules, teamDayStatus, teamMembers, teams, users } from "@/app/_domains/teamSchedules/_server/schema"
-import { getSessionUserId, assertTeamMember } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, assertTeamMember, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
 import { isDayKey, isScheduleStatus, isUuid, isValidNote } from "@/app/_domains/teamSchedules/_server/validators"
 import type { LolRoleFlags, ScheduleEntry, TeamDayStatusEntry, TeamSchedule, TeamScheduleMember } from "@/app/_domains/teamSchedules/types"
 import { ServerTiming } from "@/app/_server/lib/serverTiming"
@@ -124,6 +124,11 @@ export async function PUT(req: NextRequest, ctx: RouteContext): Promise<NextResp
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
     }
 
+    // 利用停止中ユーザーは書き込み不可（#166）
+    if (await isUserSuspended(userId)) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
+    }
+
     const body = (await req.json().catch(() => null)) as { day?: unknown; status?: unknown; note?: unknown } | null
     if (!body || !isDayKey(body.day) || !isScheduleStatus(body.status) || !isValidNote(body.note)) {
       return NextResponse.json({ success: false, error: "入力が不正です" }, { status: 400 })
@@ -166,6 +171,11 @@ export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextR
     const userId = await getSessionUserId(req)
     if (!userId) {
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    // 利用停止中ユーザーは書き込み不可（#166）
+    if (await isUserSuspended(userId)) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
 
     const body = (await req.json().catch(() => null)) as { day?: unknown } | null

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/succession/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/succession/route.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teamMembers } from "@/app/_domains/teamSchedules/_server/schema"
-import { getSessionUserId, getTeamRole } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, getTeamRole, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
 import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
 
 type RouteContext = { params: Promise<{ teamId: string }> }
@@ -42,6 +42,11 @@ export async function POST(req: NextRequest, ctx: RouteContext): Promise<NextRes
     const userId = await getSessionUserId(req)
     if (!userId) {
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    // 利用停止中ユーザーは書き込み不可（#166）
+    if (await isUserSuspended(userId)) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
 
     const role = await getTeamRole(teamId, userId)

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/succession/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/succession/route.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teamMembers } from "@/app/_domains/teamSchedules/_server/schema"
-import { getSessionUserId, getTeamRole, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, getTeamRole, getTeamMembershipWithSuspension } from "@/app/_domains/teamSchedules/_server/authz"
 import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
 
 type RouteContext = { params: Promise<{ teamId: string }> }
@@ -44,12 +44,12 @@ export async function POST(req: NextRequest, ctx: RouteContext): Promise<NextRes
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
     }
 
-    // 利用停止中ユーザーは書き込み不可（#166）
-    if (await isUserSuspended(userId)) {
+    // 操作者の利用停止判定とロール取得を1クエリにまとめる（#166・DB往復削減）。suspend→403 を先に判定する
+    // （継承先 heir のロールは別ユーザーなので、後段で getTeamRole を個別に引く）
+    const { suspended, teamRole: role } = await getTeamMembershipWithSuspension(teamId, userId)
+    if (suspended) {
       return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
-
-    const role = await getTeamRole(teamId, userId)
     if (role === null) {
       // 非メンバー（または削除済みチーム）は存在を隠して 404
       return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.test.ts
@@ -5,9 +5,11 @@ import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
 // 認可ヘルパーをモック（非メンバー404・非admin400・admin200 のロジックを route 単体で検証する）
 const mockGetSessionUserId = vi.fn()
 const mockGetTeamRole = vi.fn()
+const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
   getTeamRole: (...args: unknown[]) => mockGetTeamRole(...args),
+  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
 }))
 
 // DB は実接続しない。書き込みが呼ばれたことだけ確認する
@@ -37,6 +39,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   // clearAllMocks は実装を消さないが、Once 上書きの取り残しを避けるため毎回デフォルトを張り直す
   selectLimit.mockResolvedValue([{ managementMode: "team" }])
+  mockIsUserSuspended.mockResolvedValue(false)
 })
 
 describe("PUT /team-schedules/teams/[teamId]/team-status", () => {
@@ -63,6 +66,15 @@ describe("PUT /team-schedules/teams/[teamId]/team-status", () => {
     const req = createTestRequest(URL, { method: "PUT", body: { day: "2026-06-14", status: "ok", note: null } })
     const res = await PUT(req, ctxFor())
     expect(res.status).toBe(400)
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("failure: 利用停止中ユーザーは403（書き込みもしない）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    mockIsUserSuspended.mockResolvedValue(true)
+    const req = createTestRequest(URL, { method: "PUT", body: { day: "2026-06-14", status: "ok", note: null } })
+    const res = await PUT(req, ctxFor())
+    expect(res.status).toBe(403)
     expect(insert).not.toHaveBeenCalled()
   })
 

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.test.ts
@@ -2,14 +2,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { PUT, DELETE } from "./route"
 import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
 
-// 認可ヘルパーをモック（非メンバー404・非admin400・admin200 のロジックを route 単体で検証する）
+// 認可ヘルパーをモック（非メンバー404・非admin400・admin200 のロジックを route 単体で検証する）。
+// route は suspend 判定とロール取得を getTeamMembershipWithSuspension の1クエリに畳んでいるため、
+// テストは従来どおり「suspended」「teamRole」を別々に与えられるよう、2つの粒度モックから合成する。
 const mockGetSessionUserId = vi.fn()
 const mockGetTeamRole = vi.fn()
 const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
-  getTeamRole: (...args: unknown[]) => mockGetTeamRole(...args),
-  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
+  getTeamMembershipWithSuspension: async (...args: unknown[]) => ({
+    suspended: await mockIsUserSuspended(...args),
+    teamRole: await mockGetTeamRole(...args),
+  }),
 }))
 
 // DB は実接続しない。書き込みが呼ばれたことだけ確認する

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teamDayStatus, teams } from "@/app/_domains/teamSchedules/_server/schema"
-import { getSessionUserId, getTeamRole, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, getTeamMembershipWithSuspension } from "@/app/_domains/teamSchedules/_server/authz"
 import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
 import { isDayKey, isScheduleStatus, isUuid, isValidNote } from "@/app/_domains/teamSchedules/_server/validators"
 
@@ -28,12 +28,11 @@ async function authorizeTeamStatusAdmin(req: NextRequest, teamId: string): Promi
     return { ok: false, res: NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 }) }
   }
 
-  // 利用停止中ユーザーは書き込み不可（#166）。ログイン確認の直後に判定する
-  if (await isUserSuspended(userId)) {
+  // 利用停止判定とロール取得を1クエリにまとめる（#166・DB往復削減）。suspend→403 を先に判定する
+  const { suspended, teamRole: role } = await getTeamMembershipWithSuspension(teamId, userId)
+  if (suspended) {
     return { ok: false, res: NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 }) }
   }
-
-  const role = await getTeamRole(teamId, userId)
   if (role === null) {
     return { ok: false, res: NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 }) }
   }

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/team-status/route.ts
@@ -2,7 +2,7 @@ import { and, eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teamDayStatus, teams } from "@/app/_domains/teamSchedules/_server/schema"
-import { getSessionUserId, getTeamRole } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSessionUserId, getTeamRole, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
 import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
 import { isDayKey, isScheduleStatus, isUuid, isValidNote } from "@/app/_domains/teamSchedules/_server/validators"
 
@@ -26,6 +26,11 @@ async function authorizeTeamStatusAdmin(req: NextRequest, teamId: string): Promi
   const userId = await getSessionUserId(req)
   if (!userId) {
     return { ok: false, res: NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 }) }
+  }
+
+  // 利用停止中ユーザーは書き込み不可（#166）。ログイン確認の直後に判定する
+  if (await isUserSuspended(userId)) {
+    return { ok: false, res: NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 }) }
   }
 
   const role = await getTeamRole(teamId, userId)

--- a/my-app/app/api/web/team-schedules/teams/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/route.test.ts
@@ -5,9 +5,11 @@ import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
 // 認可ヘルパーをモック（未ログイン401・権限なし403・作成成功 のロジックを route 単体で検証する）
 const mockGetSessionUserId = vi.fn()
 const mockCanCreateTeam = vi.fn()
+const mockIsUserSuspended = vi.fn()
 vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   getSessionUserId: (...args: unknown[]) => mockGetSessionUserId(...args),
   canCreateTeam: (...args: unknown[]) => mockCanCreateTeam(...args),
+  isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
 }))
 
 // DB は実接続しない。
@@ -33,6 +35,8 @@ beforeEach(() => {
   vi.clearAllMocks()
   insertReturning.mockResolvedValue([TEAM])
   selectFrom.mockResolvedValue([])
+  // デフォルトは利用停止でない（個別テストで上書き）
+  mockIsUserSuspended.mockResolvedValue(false)
 })
 
 describe("GET /team-schedules/teams", () => {
@@ -58,6 +62,14 @@ describe("POST /team-schedules/teams", () => {
   it("failure: 作成権限が無ければ403（作成しない）", async () => {
     mockGetSessionUserId.mockResolvedValue("user-1")
     mockCanCreateTeam.mockResolvedValue(false)
+    const res = await POST(createTestRequest(URL, { method: "POST", body: validBody }))
+    expect(res.status).toBe(403)
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it("failure: 利用停止中ユーザーは403（作成しない）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    mockIsUserSuspended.mockResolvedValue(true)
     const res = await POST(createTestRequest(URL, { method: "POST", body: validBody }))
     expect(res.status).toBe(403)
     expect(insert).not.toHaveBeenCalled()

--- a/my-app/app/api/web/team-schedules/teams/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/route.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teamMembers, teams } from "@/app/_domains/teamSchedules/_server/schema"
-import { canCreateTeam, getSessionUserId } from "@/app/_domains/teamSchedules/_server/authz"
+import { canCreateTeam, getSessionUserId, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
 import { isManagementMode, isValidRequiredCount, isValidTeamDescription, isValidTeamName } from "@/app/_domains/teamSchedules/_server/validators"
 import type { TeamSummary } from "@/app/_domains/teamSchedules/types"
 import { ServerTiming } from "@/app/_server/lib/serverTiming"
@@ -61,6 +61,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     const userId = await getSessionUserId(req)
     if (!userId) {
       return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    // 利用停止中ユーザーは書き込み不可（#166）
+    if (await isUserSuspended(userId)) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
     }
 
     // 作成権限（許可された Discord ID を持つユーザーのみ）

--- a/my-app/app/developers/team-schedules/_components/DiscordBanSection.tsx
+++ b/my-app/app/developers/team-schedules/_components/DiscordBanSection.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { useState } from "react"
+import type { AdminDiscordBan } from "@/app/_domains/teamSchedules/types"
+import { formatDateTime } from "../_utils"
+
+type Props = {
+  bans: AdminDiscordBan[]
+  onAddBan: (discordUserId: string, reason: string | null) => Promise<void>
+  onRemoveBan: (discordUserId: string) => void
+}
+
+/** ③ Discord BAN 管理（一覧＋追加＋解除）。新規ログインのみ遮断する旨を注記する */
+export function DiscordBanSection({ bans, onAddBan, onRemoveBan }: Props) {
+  const [discordUserId, setDiscordUserId] = useState("")
+  const [reason, setReason] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleAdd = async () => {
+    if (submitting) return
+    setError(null)
+    const id = discordUserId.trim()
+    if (!id) {
+      setError("Discord ID を入力してください")
+      return
+    }
+    // サーバー側バリデーション（数字15〜21桁）と揃え、送信前にインラインで弾く
+    if (!/^\d{15,21}$/.test(id)) {
+      setError("Discord ID は数字のみ（15〜21桁）で入力してください")
+      return
+    }
+    setSubmitting(true)
+    try {
+      await onAddBan(id, reason.trim() === "" ? null : reason.trim())
+      setDiscordUserId("")
+      setReason("")
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "BAN の追加に失敗しました")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section>
+      <h2 className="mb-1 text-lg font-bold">Discord BAN 管理（{bans.length}）</h2>
+
+      {/* 運用者の誤解防止: 既ログインユーザーは即時失効しないことを明記（#166） */}
+      <p className="mb-3 rounded-lg border border-amber-700/60 bg-amber-950/40 p-3 text-xs leading-relaxed text-amber-200">
+        ⚠️ BAN は<strong>新規ログイン（magic-link）のみ</strong>を遮断します。すでにログイン中のユーザーは最大30日のセッションが残るため、<strong>即時ログアウトされません</strong>
+        （利用者ページ側での即時失効は将来対応）。
+      </p>
+
+      <div className="mb-4 rounded-xl border border-zinc-700 bg-zinc-900/60 p-4">
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-xs text-zinc-400">
+            Discord ID（数字）
+            <input
+              value={discordUserId}
+              onChange={(e) => setDiscordUserId(e.target.value)}
+              placeholder="例: 123456789012345678"
+              className="w-64 rounded-md border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-sm text-zinc-100"
+            />
+          </label>
+          <label className="flex flex-1 flex-col gap-1 text-xs text-zinc-400">
+            理由（任意）
+            <input
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="例: スパム"
+              className="w-full min-w-45 rounded-md border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-sm text-zinc-100"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => void handleAdd()}
+            disabled={submitting}
+            className="rounded-lg bg-rose-700 px-4 py-2 text-sm font-medium text-white hover:bg-rose-600 disabled:opacity-50"
+          >
+            {submitting ? "追加中…" : "BAN 追加"}
+          </button>
+        </div>
+        {error && <p className="mt-2 text-xs text-rose-400">{error}</p>}
+      </div>
+
+      {bans.length === 0 ? (
+        <p className="text-sm text-zinc-400">BAN 済みの Discord ID はありません。</p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-zinc-700 bg-zinc-900/60">
+          <table className="w-full min-w-140 border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-zinc-700 text-left text-xs text-zinc-400">
+                <th className="px-3 py-2 font-medium">Discord ID</th>
+                <th className="px-3 py-2 font-medium">理由</th>
+                <th className="px-3 py-2 font-medium">BAN 日時</th>
+                <th className="px-3 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {bans.map((b) => (
+                <tr key={b.discordUserId} className="border-b border-zinc-800">
+                  <td className="px-3 py-2 break-all font-mono text-[11px] text-zinc-300">{b.discordUserId}</td>
+                  <td className="px-3 py-2 text-zinc-300">{b.reason ?? "—"}</td>
+                  <td className="px-3 py-2 text-zinc-300">{formatDateTime(b.bannedAt)}</td>
+                  <td className="px-3 py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => onRemoveBan(b.discordUserId)}
+                      className="rounded-md border border-zinc-600 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+                    >
+                      解除
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/my-app/app/developers/team-schedules/_components/OrphanUsersSection.tsx
+++ b/my-app/app/developers/team-schedules/_components/OrphanUsersSection.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import type { AdminOrphanUser } from "@/app/_domains/teamSchedules/types"
+import { formatDateTime, formatDiscordIds } from "../_utils"
+import { SuspendBadge } from "./SuspendBadge"
+
+type Props = {
+  users: AdminOrphanUser[]
+  onDeleteUser: (userId: string, displayName: string) => void
+  onToggleSuspend: (userId: string, nextSuspended: boolean) => void
+}
+
+/** ② どのチームにも所属していないユーザー（削除 / 利用停止切替） */
+export function OrphanUsersSection({ users, onDeleteUser, onToggleSuspend }: Props) {
+  return (
+    <section>
+      <h2 className="mb-1 text-lg font-bold">無所属ユーザー（{users.length}）</h2>
+      <p className="mb-3 text-xs text-zinc-400">どのチームにも所属していないユーザー。テスト用アカウントの掃除などに利用します。</p>
+      {users.length === 0 ? (
+        <p className="text-sm text-zinc-400">無所属ユーザーはいません。</p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-zinc-700 bg-zinc-900/60">
+          <table className="w-full min-w-[640px] border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-zinc-700 text-left text-xs text-zinc-400">
+                <th className="px-3 py-2 font-medium">表示名</th>
+                <th className="px-3 py-2 font-medium">Discord ID</th>
+                <th className="px-3 py-2 font-medium">作成</th>
+                <th className="px-3 py-2 font-medium">状態</th>
+                <th className="px-3 py-2 text-right font-medium">操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((u) => (
+                <tr key={u.userId} className="border-b border-zinc-800 align-top">
+                  <td className="px-3 py-2">{u.displayName}</td>
+                  <td className="px-3 py-2 break-all font-mono text-[11px] text-zinc-400">{formatDiscordIds(u.discordUserIds)}</td>
+                  <td className="px-3 py-2 text-zinc-300">{formatDateTime(u.createdAt)}</td>
+                  <td className="px-3 py-2">
+                    <SuspendBadge suspended={u.suspended} />
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex justify-end gap-1.5">
+                      <button
+                        type="button"
+                        onClick={() => onToggleSuspend(u.userId, !u.suspended)}
+                        className="rounded-md border border-zinc-600 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+                      >
+                        {u.suspended ? "停止解除" : "利用停止"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onDeleteUser(u.userId, u.displayName)}
+                        className="rounded-md border border-rose-700 px-2 py-1 text-xs text-rose-300 hover:bg-rose-950/50"
+                      >
+                        削除
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/my-app/app/developers/team-schedules/_components/SuspendBadge.tsx
+++ b/my-app/app/developers/team-schedules/_components/SuspendBadge.tsx
@@ -1,0 +1,5 @@
+/** 利用停止状態のバッジ表示（停止中=赤 / 通常=控えめ） */
+export function SuspendBadge({ suspended }: { suspended: boolean }) {
+  if (!suspended) return <span className="text-xs text-zinc-500">通常</span>
+  return <span className="rounded bg-rose-900/60 px-1.5 py-0.5 text-xs font-medium text-rose-300">利用停止中</span>
+}

--- a/my-app/app/developers/team-schedules/_components/TeamSchedulesAdminPage.tsx
+++ b/my-app/app/developers/team-schedules/_components/TeamSchedulesAdminPage.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import type { AdminDiscordBan, AdminOverview } from "@/app/_domains/teamSchedules/types"
+import {
+  addDiscordBan,
+  adminDeleteTeam,
+  adminDeleteUser,
+  adminRemoveMember,
+  adminSetSuspended,
+  fetchAdminOverview,
+  fetchDiscordBans,
+  removeDiscordBan,
+} from "@/app/_client/lib/apiClient/teamSchedulesAdmin"
+import { TeamsSection } from "./TeamsSection"
+import { OrphanUsersSection } from "./OrphanUsersSection"
+import { DiscordBanSection } from "./DiscordBanSection"
+
+/**
+ * 管理ページ本体。データ取得・破壊的操作のハンドリング・レイアウトを担う。
+ * 破壊的操作は window.confirm で確認を挟む（admin 専用ツールのため簡易確認で十分）。
+ */
+export function TeamSchedulesAdminPage() {
+  const router = useRouter()
+  const [overview, setOverview] = useState<AdminOverview | null>(null)
+  const [bans, setBans] = useState<AdminDiscordBan[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  // 未ログインは /login へ（開発者ログインを流用）
+  useEffect(() => {
+    if (!localStorage.getItem("sessionToken")) router.push("/login")
+  }, [router])
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const [ov, bs] = await Promise.all([fetchAdminOverview(), fetchDiscordBans()])
+      setOverview(ov)
+      setBans(bs)
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "読み込みに失敗しました")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void reload()
+  }, [reload])
+
+  /** 破壊的操作の共通ラッパー。失敗はメッセージ表示、成功は再読み込み */
+  const run = useCallback(
+    async (action: () => Promise<void>) => {
+      setActionError(null)
+      try {
+        await action()
+        await reload()
+      } catch (e) {
+        setActionError(e instanceof Error ? e.message : "操作に失敗しました")
+      }
+    },
+    [reload],
+  )
+
+  const handleDeleteTeam = (teamId: string, name: string) => {
+    if (!window.confirm(`チーム「${name}」を強制解散します。メンバー所属・予定もすべて削除され、取り消せません。実行しますか？`)) return
+    void run(() => adminDeleteTeam(teamId))
+  }
+
+  const handleRemoveMember = (teamId: string, userId: string, displayName: string) => {
+    if (!window.confirm(`「${displayName}」をこのチームから除外します。実行しますか？`)) return
+    void run(() => adminRemoveMember(teamId, userId))
+  }
+
+  const handleDeleteUser = (userId: string, displayName: string) => {
+    if (!window.confirm(`ユーザー「${displayName}」を完全削除します。所属・予定・Discord紐づけもすべて削除され、取り消せません。実行しますか？`)) return
+    void run(() => adminDeleteUser(userId))
+  }
+
+  const handleToggleSuspend = (userId: string, nextSuspended: boolean) => {
+    void run(() => adminSetSuspended(userId, nextSuspended))
+  }
+
+  // BAN 追加はフォーム側（DiscordBanSection）でエラー表示するため run() で握り潰さず例外を伝播させる。
+  // 成功時のみ再読み込みする（失敗時は例外を投げ、フォームの入力値を保持したままインラインで表示）。
+  const handleAddBan = async (discordUserId: string, reason: string | null) => {
+    setActionError(null)
+    await addDiscordBan(discordUserId, reason)
+    await reload()
+  }
+
+  const handleRemoveBan = (discordUserId: string) => {
+    if (!window.confirm(`Discord ID「${discordUserId}」の BAN を解除します。実行しますか？`)) return
+    void run(() => removeDiscordBan(discordUserId))
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl p-6 text-zinc-100">
+      <header className="mb-6 flex items-center justify-between gap-4">
+        <h1 className="text-2xl font-bold">スクリム調整 管理画面</h1>
+        <button
+          type="button"
+          onClick={() => void reload()}
+          disabled={loading}
+          className="rounded-lg border border-zinc-600 px-3 py-1.5 text-sm font-medium text-zinc-200 hover:bg-zinc-800 disabled:opacity-50"
+        >
+          {loading ? "読み込み中…" : "再読み込み"}
+        </button>
+      </header>
+
+      {loadError && <p className="mb-4 rounded-lg border border-rose-700 bg-rose-950/50 p-3 text-sm text-rose-300">{loadError}</p>}
+      {actionError && <p className="mb-4 rounded-lg border border-rose-700 bg-rose-950/50 p-3 text-sm text-rose-300">{actionError}</p>}
+
+      {loading && !overview ? (
+        <p className="text-sm text-zinc-400">読み込み中…</p>
+      ) : overview ? (
+        <div className="space-y-10">
+          <TeamsSection teams={overview.teams} onDeleteTeam={handleDeleteTeam} onRemoveMember={handleRemoveMember} onToggleSuspend={handleToggleSuspend} />
+          <OrphanUsersSection users={overview.orphanUsers} onDeleteUser={handleDeleteUser} onToggleSuspend={handleToggleSuspend} />
+          <DiscordBanSection bans={bans} onAddBan={handleAddBan} onRemoveBan={handleRemoveBan} />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/my-app/app/developers/team-schedules/_components/TeamsSection.tsx
+++ b/my-app/app/developers/team-schedules/_components/TeamsSection.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import type { AdminTeam } from "@/app/_domains/teamSchedules/types"
+import { formatDateTime, formatDiscordIds, formatRoles } from "../_utils"
+import { SuspendBadge } from "./SuspendBadge"
+
+type Props = {
+  teams: AdminTeam[]
+  onDeleteTeam: (teamId: string, name: string) => void
+  onRemoveMember: (teamId: string, userId: string, displayName: string) => void
+  onToggleSuspend: (userId: string, nextSuspended: boolean) => void
+}
+
+const MODE_LABEL: Record<AdminTeam["managementMode"], string> = { members: "メンバー集計", team: "チーム単位" }
+
+/** ① チーム一覧＋設定＋メンバー（強制解散 / メンバー除外 / 利用停止切替） */
+export function TeamsSection({ teams, onDeleteTeam, onRemoveMember, onToggleSuspend }: Props) {
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-bold">チーム一覧（{teams.length}）</h2>
+      {teams.length === 0 ? (
+        <p className="text-sm text-zinc-400">チームはありません。</p>
+      ) : (
+        <div className="space-y-5">
+          {teams.map((team) => (
+            <div key={team.teamId} className="rounded-xl border border-zinc-700 bg-zinc-900/60 p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-base font-bold">{team.name}</p>
+                  <p className="mt-0.5 text-xs text-zinc-400">
+                    モード: {MODE_LABEL[team.managementMode]} / 活動可能人数: {team.requiredCount} / 作成: {formatDateTime(team.createdAt)}
+                  </p>
+                  <p className="mt-0.5 break-all font-mono text-[11px] text-zinc-500">team_id: {team.teamId}</p>
+                  {team.description && <p className="mt-1 text-sm text-zinc-300">{team.description}</p>}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onDeleteTeam(team.teamId, team.name)}
+                  className="shrink-0 rounded-lg bg-rose-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-rose-600"
+                >
+                  強制解散
+                </button>
+              </div>
+
+              <div className="mt-3 overflow-x-auto">
+                <table className="w-full min-w-[640px] border-collapse text-sm">
+                  <thead>
+                    <tr className="border-b border-zinc-700 text-left text-xs text-zinc-400">
+                      <th className="px-2 py-1.5 font-medium">表示名</th>
+                      <th className="px-2 py-1.5 font-medium">ロール</th>
+                      <th className="px-2 py-1.5 font-medium">担当</th>
+                      <th className="px-2 py-1.5 font-medium">Discord ID</th>
+                      <th className="px-2 py-1.5 font-medium">状態</th>
+                      <th className="px-2 py-1.5 text-right font-medium">操作</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {team.members.map((m) => (
+                      <tr key={m.userId} className="border-b border-zinc-800 align-top">
+                        <td className="px-2 py-1.5">{m.displayName}</td>
+                        <td className="px-2 py-1.5">{m.teamRole}</td>
+                        <td className="px-2 py-1.5 text-zinc-300">{formatRoles(m.roles)}</td>
+                        <td className="px-2 py-1.5 break-all font-mono text-[11px] text-zinc-400">{formatDiscordIds(m.discordUserIds)}</td>
+                        <td className="px-2 py-1.5">
+                          <SuspendBadge suspended={m.suspended} />
+                        </td>
+                        <td className="px-2 py-1.5">
+                          <div className="flex justify-end gap-1.5">
+                            <button
+                              type="button"
+                              onClick={() => onToggleSuspend(m.userId, !m.suspended)}
+                              className="rounded-md border border-zinc-600 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+                            >
+                              {m.suspended ? "停止解除" : "利用停止"}
+                            </button>
+                            {m.teamRole !== "master" && (
+                              <button
+                                type="button"
+                                onClick={() => onRemoveMember(team.teamId, m.userId, m.displayName)}
+                                className="rounded-md border border-rose-700 px-2 py-1 text-xs text-rose-300 hover:bg-rose-950/50"
+                              >
+                                除外
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/my-app/app/developers/team-schedules/_utils.ts
+++ b/my-app/app/developers/team-schedules/_utils.ts
@@ -1,0 +1,27 @@
+import type { LolRoleFlags } from "@/app/_domains/teamSchedules/types"
+
+/** can-play な LoL ロールを表示用に整形する（無ければ "—"） */
+export function formatRoles(roles: LolRoleFlags): string {
+  const labels: [keyof LolRoleFlags, string][] = [
+    ["top", "TOP"],
+    ["jungle", "JG"],
+    ["mid", "MID"],
+    ["adc", "ADC"],
+    ["support", "SUP"],
+  ]
+  const enabled = labels.filter(([k]) => roles[k]).map(([, label]) => label)
+  return enabled.length > 0 ? enabled.join(" / ") : "—"
+}
+
+/** ISO 文字列を「YYYY-MM-DD HH:mm」のローカル表記に整形する（不正値はそのまま返す） */
+export function formatDateTime(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+/** Discord ID 配列を表示用に整形する（無ければ "（紐づけ無し）"） */
+export function formatDiscordIds(ids: string[]): string {
+  return ids.length > 0 ? ids.join(", ") : "（紐づけ無し）"
+}

--- a/my-app/app/developers/team-schedules/page.tsx
+++ b/my-app/app/developers/team-schedules/page.tsx
@@ -1,0 +1,10 @@
+import { TeamSchedulesAdminPage } from "./_components/TeamSchedulesAdminPage"
+
+/**
+ * 開発者用 スクリム調整 管理ページ（#166）。
+ * 認証は開発者ログイン（localStorage.sessionToken）を流用し、未ログインは /login へ。
+ * エントリーは薄く保ち、状態管理・レイアウトは _components/TeamSchedulesAdminPage に委譲する。
+ */
+export default function Page() {
+  return <TeamSchedulesAdminPage />
+}

--- a/my-app/drizzle/0004_loving_magdalene.sql
+++ b/my-app/drizzle/0004_loving_magdalene.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "discord_bans" (
+	"discord_user_id" text PRIMARY KEY NOT NULL,
+	"reason" text,
+	"banned_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "suspended" boolean DEFAULT false NOT NULL;

--- a/my-app/drizzle/meta/0004_snapshot.json
+++ b/my-app/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,559 @@
+{
+  "id": "08d6b230-817e-4247-bbb8-e4b8100cf939",
+  "prevId": "0baa93fa-2e60-4246-ba62-84210a40208f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.discord_bans": {
+      "name": "discord_bans",
+      "schema": "",
+      "columns": {
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_links": {
+      "name": "discord_links",
+      "schema": "",
+      "columns": {
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_links_user": {
+          "name": "idx_discord_links_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_links_user_id_users_user_id_fk": {
+          "name": "discord_links_user_id_users_user_id_fk",
+          "tableFrom": "discord_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_schedules_team_day": {
+          "name": "idx_schedules_team_day",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_team_member_fk": {
+          "name": "schedules_team_member_fk",
+          "tableFrom": "schedules",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "team_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "schedules_team_id_user_id_day_pk": {
+          "name": "schedules_team_id_user_id_day_pk",
+          "columns": [
+            "team_id",
+            "user_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schedules_status_chk": {
+          "name": "schedules_status_chk",
+          "value": "\"schedules\".\"status\" in ('ok', 'maybe', 'ng')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_day_status": {
+      "name": "team_day_status",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_day_status_team_id_teams_team_id_fk": {
+          "name": "team_day_status_team_id_teams_team_id_fk",
+          "tableFrom": "team_day_status",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_day_status_team_id_day_pk": {
+          "name": "team_day_status_team_id_day_pk",
+          "columns": [
+            "team_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_day_status_status_chk": {
+          "name": "team_day_status_status_chk",
+          "value": "\"team_day_status\".\"status\" in ('ok', 'maybe', 'ng')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "top": {
+          "name": "top",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "jungle": {
+          "name": "jungle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mid": {
+          "name": "mid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "adc": {
+          "name": "adc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "support": {
+          "name": "support",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_team_members_one_master": {
+          "name": "uq_team_members_one_master",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_members\".\"team_role\" = 'master'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_members_user": {
+          "name": "idx_team_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_team_id_fk": {
+          "name": "team_members_team_id_teams_team_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_user_id_fk": {
+          "name": "team_members_user_id_users_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_invited_by_users_user_id_fk": {
+          "name": "team_members_invited_by_users_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_team_id_user_id_pk": {
+          "name": "team_members_team_id_user_id_pk",
+          "columns": [
+            "team_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_members_team_role_chk": {
+          "name": "team_members_team_role_chk",
+          "value": "\"team_members\".\"team_role\" in ('master', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_count": {
+          "name": "required_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "management_mode": {
+          "name": "management_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "teams_required_count_chk": {
+          "name": "teams_required_count_chk",
+          "value": "\"teams\".\"required_count\" >= 1"
+        },
+        "teams_management_mode_chk": {
+          "name": "teams_management_mode_chk",
+          "value": "\"teams\".\"management_mode\" in ('members', 'team')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/my-app/drizzle/meta/_journal.json
+++ b/my-app/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781617787557,
       "tag": "0003_hot_mimic",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1781954610788,
+      "tag": "0004_loving_magdalene",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
スクリム調整機能（`/team_schedules`）に開発者向け管理画面・利用停止(suspend)・Discord BAN を追加する。レビュー指摘を受けた後追いの改善（DB往復削減・BAN理由の上書き）も含む。

## close 予定 issue（develop base のため一覧のみ。develop→main PR で `Closes` 列挙）
- close #166

## 主な変更
### 機能本体（7a2e863）
- 開発者用 管理画面 `/developers/team-schedules`（全チーム＋メンバー＋無所属ユーザー一覧、チーム強制解散・メンバー除外・ユーザー削除、利用停止トグル、Discord BAN 追加/解除）
- `users.suspended` を追加し書き込み系 API で suspend 中は 403（脱退・アカウント削除は自己片付けとして意図的に許可）
- `discord_bans` テーブルを追加し `auth/verify` で BAN 済み Discord ID の新規ログインを遮断
- 管理 API（`admin/**`）は開発者ログイン（`validateAuthHeader`）で権限分離
- マイグレーション 0004

### 後追い改善（このPRで追加）
- **perf: 書き込み系の suspend 判定とロール取得を1クエリに畳む**（7dc0c8f）
  - インフラ都合で1クエリごとにコネクションを貼り直すため往復が高コスト。`isUserSuspended` と `getTeamRole`/`assertTeamMember`/`assertTeamAdmin` の2往復を、`getTeamMembershipWithSuspension`（users 起点で team_members を LEFT JOIN）で1往復に。
  - 判定順序・ステータスコードは従来と同一を維持。各 route.test は粒度モックの合成でテスト本体無改修。
- **fix: Discord BAN 再登録時に理由・BAN日時を上書き**（abb5e14）
  - `onConflictDoNothing`（冪等）だと再BANで理由が更新されず旧理由のまま success を返していた問題を `onConflictDoUpdate` で修正。

## 検証
- `npx tsc --noEmit` パス / `npm run lint` クリーン
- team_schedules 関連テスト 92件 green
- E2E 手順は #166 本文の検証セクション参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)