### PR TITLE
feat: 他チームのスケジュール閲覧に相互共有の合意を必須化（#175）

### DIFF
--- a/my-app/app/_client/lib/apiClient/teamSchedulesAdmin.ts
+++ b/my-app/app/_client/lib/apiClient/teamSchedulesAdmin.ts
@@ -39,7 +39,7 @@ async function request<T>(endpoint: string, init: { method: string; body?: objec
 /** 全チーム＋設定＋メンバー＋無所属ユーザーを取得 */
 export async function fetchAdminOverview(): Promise<AdminOverview> {
   const json = await request<AdminOverview>("/overview", { method: "GET" }, "管理データの取得に失敗しました")
-  return { teams: json.teams ?? [], orphanUsers: json.orphanUsers ?? [] }
+  return { teams: json.teams ?? [], orphanUsers: json.orphanUsers ?? [], shares: json.shares ?? [] }
 }
 
 /** チームを強制解散する（取り消し不可） */

--- a/my-app/app/_domains/teamSchedules/_client/teamSchedulesApiClient.ts
+++ b/my-app/app/_domains/teamSchedules/_client/teamSchedulesApiClient.ts
@@ -1,4 +1,4 @@
-import type { DayKey, ScheduleStatus, SessionUser, TeamManagementMode, TeamSchedule, TeamSummary, TeamWebhookSlotPatch, TeamWebhookView, WebhookProvider, WebhookSlot } from "@/app/_domains/teamSchedules/types"
+import type { DayKey, ScheduleStatus, SessionUser, SharePreview, TeamManagementMode, TeamSchedule, TeamSummary, TeamWebhookSlotPatch, TeamWebhookView, WebhookProvider, WebhookSlot } from "@/app/_domains/teamSchedules/types"
 
 /**
  * スクリム調整機能の Web API クライアント。
@@ -104,6 +104,42 @@ export async function joinTeam(token: string): Promise<TeamSummary> {
   const json = await parse<{ team?: TeamSummary }>(res, "チームへの参加に失敗しました")
   if (!json.team) throw new Error("チームへの参加に失敗しました")
   return json.team
+}
+
+/**
+ * 他チームとスケジュールを共有するための招待リンクを発行する（要ログイン + admin・#175）。
+ * createInvite と同型。受諾用URL（?share=&from=）を返す。
+ */
+export async function createShareInvite(teamId: string): Promise<{ url: string; expiryDays: number }> {
+  const res = await fetch(`${API_BASE}/teams/${encodeURIComponent(teamId)}/share-invite`, { method: "POST" })
+  const json = await parse<{ url?: string; expiryDays?: number }>(res, "共有リンクの発行に失敗しました")
+  if (!json.url) throw new Error("共有リンクの発行に失敗しました")
+  return { url: json.url, expiryDays: json.expiryDays ?? 0 }
+}
+
+/** 共有リンクのトークンから確認画面用の情報を取得する（要ログイン・#175） */
+export async function fetchSharePreview(token: string): Promise<SharePreview> {
+  const params = new URLSearchParams({ token })
+  const res = await fetch(`${API_BASE}/shares/preview?${params}`, { cache: "no-store" })
+  const json = await parse<{ preview?: SharePreview }>(res, "共有リンクの確認に失敗しました")
+  if (!json.preview) throw new Error("共有リンクの確認に失敗しました")
+  return json.preview
+}
+
+/** 共有リンクを受諾して、自分の所属チーム（acceptTeamId）と相手チームを相互共有する（要ログイン + admin・#175） */
+export async function acceptShare(token: string, acceptTeamId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/shares`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token, acceptTeamId }),
+  })
+  await parse<Record<string, never>>(res, "スケジュール共有の開始に失敗しました")
+}
+
+/** 相手チームとのスケジュール共有を解除する（要ログイン + admin・両者から見えなくなる・#175） */
+export async function deleteShare(teamId: string, partnerTeamId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/teams/${encodeURIComponent(teamId)}/shares/${encodeURIComponent(partnerTeamId)}`, { method: "DELETE" })
+  await parse<Record<string, never>>(res, "スケジュール共有の解除に失敗しました")
 }
 
 /** ログイン中ユーザー自身がチームを脱退する（要ログイン）。master は脱退不可（サーバーが400を返す） */

--- a/my-app/app/_domains/teamSchedules/_server/magicLink.ts
+++ b/my-app/app/_domains/teamSchedules/_server/magicLink.ts
@@ -1,0 +1,30 @@
+import { randomBytes } from "crypto"
+import { redisSet } from "@/app/_server/lib/redis/redis"
+import { magicLinkKey } from "@/app/_domains/teamSchedules/_server/redisKeys"
+import { APP_URL } from "@/app/_server/lib/env"
+
+/** magic-link の有効期限（秒）。発行・検証・案内文の表示で共有する */
+export const MAGIC_LINK_TTL = 600 // 10分
+
+/** Redis に保存する magic-link の中身（auth/verify で利用） */
+export type MagicLinkPayload = {
+  discordUserId: string
+  username: string
+}
+
+/**
+ * ワンタイムのログイン用URLを発行する（トークン生成 + Redis保存）。
+ * URL を知れば誰でもそのユーザーとしてログインできるため、必ず本人にだけ届く
+ * ephemeral メッセージで提示すること。
+ *
+ * teamId を渡すと `?token=...&team=...` を付け、ログイン後に対象チームを
+ * 自チーム選択した状態で開く（team_schedules 画面が token を消費しつつ team は残す）。
+ */
+export async function createMagicLinkUrl(discordUserId: string, username: string, teamId?: string): Promise<string> {
+  const token = randomBytes(32).toString("hex")
+  const payload: MagicLinkPayload = { discordUserId, username }
+  await redisSet(magicLinkKey(token), payload, MAGIC_LINK_TTL)
+
+  const url = `${APP_URL}/team_schedules?token=${token}`
+  return teamId ? `${url}&team=${encodeURIComponent(teamId)}` : url
+}

--- a/my-app/app/_domains/teamSchedules/_server/redisKeys.ts
+++ b/my-app/app/_domains/teamSchedules/_server/redisKeys.ts
@@ -19,3 +19,8 @@ export function userSessionKey(token: string): string {
 export function inviteKey(token: string): string {
   return `ts:invite:${token}`
 }
+
+/** スケジュール共有トークン（TTL付き・受諾されても削除せず TTL で失効・#175）。値は { sourceTeamId } */
+export function shareKey(token: string): string {
+  return `ts:share:${token}`
+}

--- a/my-app/app/_domains/teamSchedules/_server/schema.ts
+++ b/my-app/app/_domains/teamSchedules/_server/schema.ts
@@ -187,6 +187,31 @@ export const discordBans = pgTable("discord_bans", {
   bannedAt: timestamp("banned_at", { withTimezone: true }).notNull().defaultNow(),
 })
 
+// team_shares: チーム間のスケジュール相互共有（#175）。1共有=1行（順序づけペア team_low < team_high）。
+// 共有は対称(A↔B)かつ非推移(A-B・B-C があっても A-C は見えない)。neon-http はトランザクション非対応なので
+// 1行=1関係で原子的に扱う（2行案だと片側 INSERT 失敗で片側だけ見える不整合が起こりうる）。
+// 注: team_webhooks.slot='shared'（通知の共有先）とは無関係の別概念で、こちらは閲覧権の相互共有。
+export const teamShares = pgTable(
+  "team_shares",
+  {
+    teamLow: uuid("team_low")
+      .notNull()
+      .references(() => teams.teamId, { onDelete: "cascade" }),
+    teamHigh: uuid("team_high")
+      .notNull()
+      .references(() => teams.teamId, { onDelete: "cascade" }),
+    // 共有を成立させた受諾側の userId（監査用・任意）。発行者アカウント削除時は記録を残して null 化。
+    createdBy: uuid("created_by").references(() => users.userId, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.teamLow, t.teamHigh] }),
+    // 順序づけ（team_low < team_high）＋自己共有禁止を同時に担保。(A,B)=(B,A) の重複も PK で弾く
+    check("team_shares_order_chk", sql`${t.teamLow} < ${t.teamHigh}`),
+    index("idx_team_shares_high").on(t.teamHigh), // team_high 側からの逆引き（team_low は PK 先頭でカバー）
+  ],
+)
+
 // 推論される型（クエリ結果や INSERT 値に効く）
 export type Team = typeof teams.$inferSelect
 export type NewTeam = typeof teams.$inferInsert
@@ -206,3 +231,5 @@ export type ScheduleNotification = typeof scheduleNotifications.$inferSelect
 export type NewScheduleNotification = typeof scheduleNotifications.$inferInsert
 export type DiscordBan = typeof discordBans.$inferSelect
 export type NewDiscordBan = typeof discordBans.$inferInsert
+export type TeamShare = typeof teamShares.$inferSelect
+export type NewTeamShare = typeof teamShares.$inferInsert

--- a/my-app/app/_domains/teamSchedules/_server/shares.test.ts
+++ b/my-app/app/_domains/teamSchedules/_server/shares.test.ts
@@ -39,6 +39,17 @@ describe("teamSchedules shares helpers", () => {
       const y = "22222222-2222-2222-2222-222222222222"
       expect(orderPair(y, x)).toEqual({ teamLow: x, teamHigh: y })
     })
+
+    it("success: 大小混在の入力は小文字へ正規化してから順序づけする（Postgres uuid 比較との整合・CHECK違反500の防止）", () => {
+      // JS の ASCII 比較では "B..."(0x42) < "a..."(0x61) だが、小文字化すると "b" > "a"。
+      // 正規化しないと team_low に大文字 B が来て DB の team_low<team_high を破る。
+      const upperB = "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB"
+      const lowerA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+      expect(orderPair(upperB, lowerA)).toEqual({
+        teamLow: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        teamHigh: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      })
+    })
   })
 
   describe("getSharePartners", () => {

--- a/my-app/app/_domains/teamSchedules/_server/shares.test.ts
+++ b/my-app/app/_domains/teamSchedules/_server/shares.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+
+// db をテーブル identity で出し分ける。
+// - getUserTeamIds: select().from(teamMembers).where() → memberRows
+// - getSharePartners / getSharePartnersForTeams: select().from(teamShares).where() → shareRows
+const h = vi.hoisted(() => ({
+  shareRows: [] as { teamLow: string; teamHigh: string }[],
+  memberRows: [] as { teamId: string }[],
+}))
+vi.mock("@/app/_server/lib/db", async () => {
+  const schema = await import("./schema")
+  return {
+    db: {
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () => Promise.resolve(table === schema.teamShares ? h.shareRows : h.memberRows),
+        }),
+      }),
+    },
+  }
+})
+
+import { orderPair, getSharePartners, getSharePartnersForTeams, isTeamVisible, isTeamVisibleTo } from "./shares"
+
+describe("teamSchedules shares helpers", () => {
+  beforeEach(() => {
+    h.shareRows = []
+    h.memberRows = []
+  })
+
+  describe("orderPair", () => {
+    it("success: 常に teamLow < teamHigh に正規化する（引数の順序によらず同じ）", () => {
+      expect(orderPair("a", "b")).toEqual({ teamLow: "a", teamHigh: "b" })
+      expect(orderPair("b", "a")).toEqual({ teamLow: "a", teamHigh: "b" })
+    })
+
+    it("success: UUID のような文字列でも辞書順で正規化する", () => {
+      const x = "11111111-1111-1111-1111-111111111111"
+      const y = "22222222-2222-2222-2222-222222222222"
+      expect(orderPair(y, x)).toEqual({ teamLow: x, teamHigh: y })
+    })
+  })
+
+  describe("getSharePartners", () => {
+    it("success: team_low 側のときは team_high を相手として返す", async () => {
+      h.shareRows = [{ teamLow: "A", teamHigh: "B" }]
+      expect(await getSharePartners("A")).toEqual(["B"])
+    })
+
+    it("success: team_high 側のときは team_low を相手として返す", async () => {
+      h.shareRows = [{ teamLow: "A", teamHigh: "B" }]
+      expect(await getSharePartners("B")).toEqual(["A"])
+    })
+
+    it("success: 共有が無ければ空配列", async () => {
+      h.shareRows = []
+      expect(await getSharePartners("A")).toEqual([])
+    })
+  })
+
+  describe("getSharePartnersForTeams", () => {
+    it("success: 自分側=key / 反対側=partner に振り分ける", async () => {
+      h.shareRows = [{ teamLow: "A", teamHigh: "B" }]
+      const map = await getSharePartnersForTeams(["A"])
+      expect(map.get("A")).toEqual(["B"])
+      expect(map.has("B")).toBe(false) // B は問い合わせ対象外なのでキーを持たない
+    })
+
+    it("success: 両端とも対象集合に含まれる共有は双方向に積む", async () => {
+      h.shareRows = [{ teamLow: "A", teamHigh: "B" }]
+      const map = await getSharePartnersForTeams(["A", "B"])
+      expect(map.get("A")).toEqual(["B"])
+      expect(map.get("B")).toEqual(["A"])
+    })
+
+    it("success: 複数の共有相手をまとめて返す", async () => {
+      h.shareRows = [
+        { teamLow: "A", teamHigh: "B" },
+        { teamLow: "A", teamHigh: "C" },
+      ]
+      const map = await getSharePartnersForTeams(["A"])
+      expect(map.get("A")?.sort()).toEqual(["B", "C"])
+    })
+
+    it("success: 空の teamIds では DB を引かず空 Map を返す", async () => {
+      h.shareRows = [{ teamLow: "A", teamHigh: "B" }]
+      const map = await getSharePartnersForTeams([])
+      expect(map.size).toBe(0)
+    })
+  })
+
+  // 可視判定の核心（#175）。純粋関数で非推移の不変条件を固定する。
+  describe("isTeamVisible（純粋ロジック・非推移）", () => {
+    it("success: 直接所属しているチームは可視", () => {
+      expect(isTeamVisible(["A"], "A", [])).toBe(true)
+    })
+
+    it("success: 対象が自分の所属チームと直接共有していれば可視", () => {
+      // 対象 B の共有相手に自分の所属 A が含まれる
+      expect(isTeamVisible(["A"], "B", ["A", "C"])).toBe(true)
+    })
+
+    it("failure: 非推移 — A-B・B-C があっても A から C は不可視", () => {
+      // 自分=A、対象=C、C の直接共有相手は B のみ（A は含まれない）→ 見えない
+      expect(isTeamVisible(["A"], "C", ["B"])).toBe(false)
+    })
+
+    it("failure: 所属でも共有相手でもなければ不可視", () => {
+      expect(isTeamVisible(["A"], "Z", [])).toBe(false)
+    })
+
+    it("failure: 所属チームが無いユーザーは何も見えない", () => {
+      expect(isTeamVisible([], "A", ["A"])).toBe(false)
+    })
+  })
+
+  // isTeamVisibleTo は getUserTeamIds + getSharePartners + isTeamVisible の合成。
+  // table identity モックで A-B-C シナリオを通し、非推移を端から端まで検証する。
+  describe("isTeamVisibleTo（DB 合成・非推移）", () => {
+    it("success: 直接所属チームは可視（共有が無くても true）", async () => {
+      h.memberRows = [{ teamId: "A" }]
+      h.shareRows = []
+      expect(await isTeamVisibleTo("A", "userA")).toBe(true)
+    })
+
+    it("success: 共有相手チームは可視（A は A-B 共有の B を見られる）", async () => {
+      h.memberRows = [{ teamId: "A" }]
+      h.shareRows = [{ teamLow: "A", teamHigh: "B" }]
+      expect(await isTeamVisibleTo("B", "userA")).toBe(true)
+    })
+
+    it("failure: 非推移 — A は B-C 共有の C を見られない", async () => {
+      // A は B と共有しているが、C は B としか共有していない（A-C の直接共有は無い）
+      h.memberRows = [{ teamId: "A" }]
+      h.shareRows = [{ teamLow: "B", teamHigh: "C" }]
+      expect(await isTeamVisibleTo("C", "userA")).toBe(false)
+    })
+
+    it("failure: 無関係チームは不可視", async () => {
+      h.memberRows = [{ teamId: "A" }]
+      h.shareRows = []
+      expect(await isTeamVisibleTo("Z", "userA")).toBe(false)
+    })
+  })
+})

--- a/my-app/app/_domains/teamSchedules/_server/shares.ts
+++ b/my-app/app/_domains/teamSchedules/_server/shares.ts
@@ -25,9 +25,16 @@ export type SharePayload = {
   sourceTeamId: string
 }
 
-/** 2つの teamId を team_low < team_high に正規化する（(A,B)=(B,A) を一意化） */
+/**
+ * 2つの teamId を team_low < team_high に正規化する（(A,B)=(B,A) を一意化）。
+ * Postgres の uuid 比較は正準小文字基準なので、小文字へ揃えてから順序づけする。
+ * これをしないと大小混在の入力で JS の文字列比較と DB がズレ、team_low<team_high の CHECK 違反（=500）になりうる
+ * （実データは gen_random_uuid 由来の小文字なので通常は no-op。手書きリクエスト対策の防御）。
+ */
 export function orderPair(a: string, b: string): { teamLow: string; teamHigh: string } {
-  return a < b ? { teamLow: a, teamHigh: b } : { teamLow: b, teamHigh: a }
+  const x = a.toLowerCase()
+  const y = b.toLowerCase()
+  return x < y ? { teamLow: x, teamHigh: y } : { teamLow: y, teamHigh: x }
 }
 
 /**

--- a/my-app/app/_domains/teamSchedules/_server/shares.ts
+++ b/my-app/app/_domains/teamSchedules/_server/shares.ts
@@ -1,0 +1,117 @@
+/**
+ * スクリム調整機能 - チーム間スケジュール相互共有（#175）
+ *
+ * 共有関係（team_shares）の問い合わせと共有トークンの発行を集約する。
+ * authz.ts（=(team,user) の直接認可）とは責務を分け、invites.ts と同列に置く。
+ *
+ * 不変条件: あるユーザーが読めるスケジュール = 所属チーム ∪ その所属チームと共有しているチーム。
+ * 共有は対称(A↔B)かつ非推移(A-B・B-C があっても A-C は見えない)。
+ * team_shares は順序づけペア（team_low < team_high）で 1共有=1行。
+ */
+
+import { randomBytes } from "crypto"
+import { and, eq, inArray, or } from "drizzle-orm"
+import { db } from "@/app/_server/lib/db"
+import { teamMembers, teamShares } from "./schema"
+import { shareKey } from "./redisKeys"
+import { redisSet } from "@/app/_server/lib/redis/redis"
+
+/** 共有トークンの有効期限（招待リンクと同型・7日） */
+export const SHARE_TTL = 60 * 60 * 24 * 7
+
+/** Redis に保存する共有トークンの中身（shares POST で利用） */
+export type SharePayload = {
+  /** 共有を申し込んだ側（リンク発行元）のチーム */
+  sourceTeamId: string
+}
+
+/** 2つの teamId を team_low < team_high に正規化する（(A,B)=(B,A) を一意化） */
+export function orderPair(a: string, b: string): { teamLow: string; teamHigh: string } {
+  return a < b ? { teamLow: a, teamHigh: b } : { teamLow: b, teamHigh: a }
+}
+
+/**
+ * 共有トークンを発行して Redis に保存し、トークン文字列を返す。
+ * 成立させた受諾側 userId は team_shares.created_by に記録するため、トークンには発行者を持たせない。
+ * @param sourceTeamId 共有を申し込む側（リンク発行元）のチーム
+ */
+export async function createShareToken(sourceTeamId: string): Promise<string> {
+  // invites.createInviteToken と同型。16バイト=128bit=32文字で 7日TTL には十分な強度。
+  const token = randomBytes(16).toString("hex")
+  const payload: SharePayload = { sourceTeamId }
+  await redisSet(shareKey(token), payload, SHARE_TTL)
+  return token
+}
+
+/** あるチームが共有している相手チームの teamId 一覧（双方向 OR で 1 SELECT） */
+export async function getSharePartners(teamId: string): Promise<string[]> {
+  const rows = await db
+    .select({ teamLow: teamShares.teamLow, teamHigh: teamShares.teamHigh })
+    .from(teamShares)
+    .where(or(eq(teamShares.teamLow, teamId), eq(teamShares.teamHigh, teamId)))
+  return rows.map((r) => (r.teamLow === teamId ? r.teamHigh : r.teamLow))
+}
+
+/**
+ * 複数チームの共有相手を 1 往復でまとめて引く（GET /teams 用）。
+ * 戻り値は teamId → 共有相手 teamId[] の Map（共有0件のチームはキーを持たない）。
+ */
+export async function getSharePartnersForTeams(teamIds: string[]): Promise<Map<string, string[]>> {
+  const result = new Map<string, string[]>()
+  if (teamIds.length === 0) return result
+  const rows = await db
+    .select({ teamLow: teamShares.teamLow, teamHigh: teamShares.teamHigh })
+    .from(teamShares)
+    .where(or(inArray(teamShares.teamLow, teamIds), inArray(teamShares.teamHigh, teamIds)))
+  const idSet = new Set(teamIds)
+  // 1行(team_low, team_high)につき、自分側=key / 反対側=partner に振り分ける。
+  // 両方が teamIds に含まれる（自分の所属2チーム同士の共有）場合は双方向に積む。
+  const push = (key: string, partner: string) => {
+    const list = result.get(key)
+    if (list) list.push(partner)
+    else result.set(key, [partner])
+  }
+  for (const r of rows) {
+    if (idSet.has(r.teamLow)) push(r.teamLow, r.teamHigh)
+    if (idSet.has(r.teamHigh)) push(r.teamHigh, r.teamLow)
+  }
+  return result
+}
+
+/** userId が所属している全チームの teamId 一覧（可視性判定の起点） */
+export async function getUserTeamIds(userId: string): Promise<string[]> {
+  const rows = await db.select({ teamId: teamMembers.teamId }).from(teamMembers).where(eq(teamMembers.userId, userId))
+  return rows.map((r) => r.teamId)
+}
+
+/**
+ * 可視判定の純粋ロジック（#175 の核心・非推移をここで担保）。
+ * 直接所属している、または対象チームの【直接の】共有相手に自分の所属チームが含まれれば可視。
+ * 対象の共有相手のさらに共有相手（2ホップ）は見ないので、A-B・B-C があっても A から C は不可視。
+ *
+ * @param myTeamIds 判定するユーザーの所属チーム
+ * @param targetTeamId 閲覧したい対象チーム
+ * @param targetSharePartners 対象チームが直接共有している相手チーム（getSharePartners(targetTeamId) の結果）
+ */
+export function isTeamVisible(myTeamIds: string[], targetTeamId: string, targetSharePartners: string[]): boolean {
+  if (myTeamIds.includes(targetTeamId)) return true // 直接所属
+  return targetSharePartners.some((p) => myTeamIds.includes(p)) // 対象と直接共有しているチームに所属
+}
+
+/**
+ * userId が teamId のスケジュールを閲覧してよいか（schedule GET の可視性ガード用）。
+ * 直接所属なら共有照会を省いて即 true（最適化）。そうでなければ対象の直接共有相手を1ホップだけ引いて判定する。
+ * 判定の本体は純粋関数 isTeamVisible に切り出し、非推移の不変条件を単体テストで固定する。
+ */
+export async function isTeamVisibleTo(teamId: string, userId: string): Promise<boolean> {
+  const myTeamIds = await getUserTeamIds(userId)
+  if (myTeamIds.includes(teamId)) return true // 直接所属なら getSharePartners を省く
+  const partners = await getSharePartners(teamId)
+  return isTeamVisible(myTeamIds, teamId, partners)
+}
+
+/** team_shares から共有を1行削除する（解除・冪等）。順序正規化して PK で1行を指す */
+export async function deleteShare(teamA: string, teamB: string): Promise<void> {
+  const { teamLow, teamHigh } = orderPair(teamA, teamB)
+  await db.delete(teamShares).where(and(eq(teamShares.teamLow, teamLow), eq(teamShares.teamHigh, teamHigh)))
+}

--- a/my-app/app/_domains/teamSchedules/types.ts
+++ b/my-app/app/_domains/teamSchedules/types.ts
@@ -64,6 +64,22 @@ export type TeamSummary = {
    * 一覧取得（GET /teams）でのみ付与。master はアカウント削除・脱退の可否判定に使う。
    */
   isMaster?: boolean
+  /**
+   * このチームがスケジュールを相互共有している相手チームの teamId 一覧（#175）。
+   * 一覧取得（GET /teams）でのみ付与。比較セレクタの相手候補と設定の共有解除一覧に使う。
+   * 共有0件のチームでは空配列。作成/参加/更新の単体レスポンスでは未設定（undefined）。
+   */
+  sharedTeamIds?: string[]
+}
+
+/**
+ * 共有リンク着地時の確認画面に出す情報（GET /shares/preview・#175）。
+ * - sourceTeam: リンクを発行した（共有を申し込む）側のチーム
+ * - acceptCandidates: 受諾者が admin 以上で結べる自分の所属チーム（sourceTeam 自身は除外）
+ */
+export type SharePreview = {
+  sourceTeam: { teamId: string; name: string }
+  acceptCandidates: { teamId: string; name: string }[]
 }
 
 /** チームの所属メンバー */
@@ -194,10 +210,20 @@ export type AdminOrphanUser = {
   createdAt: string
 }
 
+/** 管理画面に表示する共有ペア（#175）。team_shares 1行 = 1ペア（team_low < team_high） */
+export type AdminShare = {
+  teamLow: { teamId: string; name: string }
+  teamHigh: { teamId: string; name: string }
+  /** 成立日時（ISO8601 文字列） */
+  createdAt: string
+}
+
 /** GET /admin/overview のレスポンス本体 */
 export type AdminOverview = {
   teams: AdminTeam[]
   orphanUsers: AdminOrphanUser[]
+  /** チーム間スケジュール共有のペア一覧（#175） */
+  shares: AdminShare[]
 }
 
 /** Discord BAN 1件 */

--- a/my-app/app/api/web/team-schedules/admin/overview/route.ts
+++ b/my-app/app/api/web/team-schedules/admin/overview/route.ts
@@ -1,8 +1,8 @@
 import { desc, eq, notInArray } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
-import { discordLinks, teamMembers, teams, users } from "@/app/_domains/teamSchedules/_server/schema"
-import type { AdminOrphanUser, AdminOverview, AdminTeam, AdminTeamMember, LolRoleFlags } from "@/app/_domains/teamSchedules/types"
+import { discordLinks, teamMembers, teams, teamShares, users } from "@/app/_domains/teamSchedules/_server/schema"
+import type { AdminOrphanUser, AdminOverview, AdminShare, AdminTeam, AdminTeamMember, LolRoleFlags } from "@/app/_domains/teamSchedules/types"
 import { requireAdmin } from "../_auth"
 
 /**
@@ -100,7 +100,19 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       createdAt: u.createdAt.toISOString(),
     }))
 
-    const result: AdminOverview = { teams: teamList, orphanUsers }
+    // チーム間スケジュール共有のペア一覧（#175）。チーム名は teamRows から解決する
+    const nameByTeam = new Map(teamRows.map((t) => [t.teamId, t.name]))
+    const shareRows = await db
+      .select({ teamLow: teamShares.teamLow, teamHigh: teamShares.teamHigh, createdAt: teamShares.createdAt })
+      .from(teamShares)
+      .orderBy(desc(teamShares.createdAt))
+    const shares: AdminShare[] = shareRows.map((s) => ({
+      teamLow: { teamId: s.teamLow, name: nameByTeam.get(s.teamLow) ?? "(不明なチーム)" },
+      teamHigh: { teamId: s.teamHigh, name: nameByTeam.get(s.teamHigh) ?? "(不明なチーム)" },
+      createdAt: s.createdAt.toISOString(),
+    }))
+
+    const result: AdminOverview = { teams: teamList, orphanUsers, shares }
     return NextResponse.json({ success: true, ...result })
   } catch (error) {
     console.error("team-schedules admin overview GET error:", error)

--- a/my-app/app/api/web/team-schedules/shares/preview/route.ts
+++ b/my-app/app/api/web/team-schedules/shares/preview/route.ts
@@ -1,0 +1,55 @@
+import { and, eq, inArray, ne } from "drizzle-orm"
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/app/_server/lib/db"
+import { teamMembers, teams } from "@/app/_domains/teamSchedules/_server/schema"
+import { getSessionUserId } from "@/app/_domains/teamSchedules/_server/authz"
+import { shareKey } from "@/app/_domains/teamSchedules/_server/redisKeys"
+import type { SharePayload } from "@/app/_domains/teamSchedules/_server/shares"
+import { redisGet } from "@/app/_server/lib/redis/redis"
+import type { SharePreview } from "@/app/_domains/teamSchedules/types"
+
+/**
+ * GET /api/web/team-schedules/shares/preview?token=
+ * 共有リンク着地時の確認画面用情報を返す（要ログイン・#175）。
+ * - sourceTeam: リンク発行元チーム
+ * - acceptCandidates: 受諾者が admin 以上で結べる自分の所属チーム（sourceTeam 自身は除外）
+ */
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    const userId = await getSessionUserId(req)
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    const token = req.nextUrl.searchParams.get("token")
+    if (!token) {
+      return NextResponse.json({ success: false, error: "共有リンクが不正です" }, { status: 400 })
+    }
+
+    const payload = await redisGet<SharePayload>(shareKey(token))
+    if (!payload) {
+      return NextResponse.json({ success: false, error: "共有リンクの有効期限が切れているか、無効です" }, { status: 401 })
+    }
+    const { sourceTeamId } = payload
+
+    const sourceRows = await db.select({ teamId: teams.teamId, name: teams.name }).from(teams).where(eq(teams.teamId, sourceTeamId)).limit(1)
+    const sourceTeam = sourceRows[0]
+    if (!sourceTeam) {
+      // 発行元チームが解散済み等
+      return NextResponse.json({ success: false, error: "共有元のチームが見つかりません" }, { status: 404 })
+    }
+
+    // 受諾者が admin 以上で所属するチーム（sourceTeam 自身は除外＝自己共有を候補から外す）
+    const candidateRows = await db
+      .select({ teamId: teams.teamId, name: teams.name })
+      .from(teamMembers)
+      .innerJoin(teams, eq(teams.teamId, teamMembers.teamId))
+      .where(and(eq(teamMembers.userId, userId), inArray(teamMembers.teamRole, ["master", "admin"]), ne(teamMembers.teamId, sourceTeamId)))
+
+    const preview: SharePreview = { sourceTeam, acceptCandidates: candidateRows }
+    return NextResponse.json({ success: true, preview })
+  } catch (error) {
+    console.error("team-schedules shares preview GET error:", error)
+    return NextResponse.json({ success: false, error: "共有リンクの確認に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/shares/route.ts
+++ b/my-app/app/api/web/team-schedules/shares/route.ts
@@ -1,0 +1,72 @@
+import { eq } from "drizzle-orm"
+import { NextRequest, NextResponse } from "next/server"
+import { db } from "@/app/_server/lib/db"
+import { teams, teamShares } from "@/app/_domains/teamSchedules/_server/schema"
+import { getSessionUserId, getTeamMembershipWithSuspension } from "@/app/_domains/teamSchedules/_server/authz"
+import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
+import { orderPair, type SharePayload } from "@/app/_domains/teamSchedules/_server/shares"
+import { shareKey } from "@/app/_domains/teamSchedules/_server/redisKeys"
+import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
+import { redisGet } from "@/app/_server/lib/redis/redis"
+
+/**
+ * POST /api/web/team-schedules/shares
+ * 共有リンクを受諾し、自分の所属チーム（acceptTeamId）と発行元チームを相互共有する（#175）。
+ * 要ログイン + suspend不可 + acceptTeam の admin。body: { token, acceptTeamId }
+ *
+ * 共有は複数人で使う想定はないが、招待と同じく受諾後もトークンは削除しない（TTLで失効）。
+ * 既に共有済みなら何もしない（冪等・PK + onConflictDoNothing）。
+ */
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    const userId = await getSessionUserId(req)
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    const body = (await req.json().catch(() => null)) as { token?: unknown; acceptTeamId?: unknown } | null
+    const token = body?.token
+    const acceptTeamId = body?.acceptTeamId
+    if (typeof token !== "string" || !token || !isUuid(acceptTeamId)) {
+      return NextResponse.json({ success: false, error: "入力が不正です" }, { status: 400 })
+    }
+
+    // 利用停止判定と acceptTeam のロール取得を1クエリに（suspend→403 を先に）
+    const { suspended, teamRole } = await getTeamMembershipWithSuspension(acceptTeamId, userId)
+    if (suspended) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
+    }
+    // acceptTeam の admin 以上でなければ存在を隠して 404
+    if (teamRole === null || !hasAdminAuthority(teamRole)) {
+      return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+    }
+
+    const payload = await redisGet<SharePayload>(shareKey(token))
+    if (!payload) {
+      return NextResponse.json({ success: false, error: "共有リンクの有効期限が切れているか、無効です" }, { status: 401 })
+    }
+    const { sourceTeamId } = payload
+
+    // 自己共有は不可（team_low<team_high の CHECK でも弾けるが、明示的に 400 を返す）
+    if (sourceTeamId === acceptTeamId) {
+      return NextResponse.json({ success: false, error: "同じチーム同士は共有できません" }, { status: 400 })
+    }
+
+    // 発行元チームが解散済み等で存在しないなら受諾できない
+    const sourceRows = await db.select({ teamId: teams.teamId }).from(teams).where(eq(teams.teamId, sourceTeamId)).limit(1)
+    if (!sourceRows[0]) {
+      return NextResponse.json({ success: false, error: "共有元のチームが見つかりません" }, { status: 404 })
+    }
+
+    const { teamLow, teamHigh } = orderPair(sourceTeamId, acceptTeamId)
+    await db
+      .insert(teamShares)
+      .values({ teamLow, teamHigh, createdBy: userId })
+      .onConflictDoNothing({ target: [teamShares.teamLow, teamShares.teamHigh] })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("team-schedules shares POST error:", error)
+    return NextResponse.json({ success: false, error: "スケジュール共有の開始に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { PUT, DELETE } from "./route"
+import { GET, PUT, DELETE } from "./route"
 import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
+
+// 可視性ガード（#175）をモック。GET は未ログイン・非可視を 404 で存在隠蔽する
+const mockIsTeamVisibleTo = vi.fn()
+vi.mock("@/app/_domains/teamSchedules/_server/shares", () => ({
+  isTeamVisibleTo: (...args: unknown[]) => mockIsTeamVisibleTo(...args),
+}))
 
 // 認可ヘルパーをモック（本人列のみ編集可・非メンバー404 のロジックを route 単体で検証する）。
 // route は suspend 判定とメンバーシップ取得を getTeamMembershipWithSuspension の1クエリに畳んでいるため、
@@ -48,6 +54,26 @@ const ctxFor = () => ({ params: Promise.resolve({ teamId: TEAM_ID }) })
 beforeEach(() => {
   vi.clearAllMocks()
   mockIsUserSuspended.mockResolvedValue(false)
+})
+
+describe("GET /team-schedules/teams/[teamId]/schedule", () => {
+  const getUrl = `${URL}?from=2026-06-14&to=2026-06-27`
+
+  it("failure: 未ログインは404（存在隠蔽・public read 廃止・#175）", async () => {
+    mockGetSessionUserId.mockResolvedValue(null)
+    const res = await GET(createTestRequest(getUrl), ctxFor())
+    expect(res.status).toBe(404)
+    // 可視性判定にも到達しない
+    expect(mockIsTeamVisibleTo).not.toHaveBeenCalled()
+  })
+
+  it("failure: 所属でも共有でもないチームは404（存在隠蔽・#175）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    mockIsTeamVisibleTo.mockResolvedValue(false)
+    const res = await GET(createTestRequest(getUrl), ctxFor())
+    expect(res.status).toBe(404)
+    expect(mockIsTeamVisibleTo).toHaveBeenCalledWith(TEAM_ID, "user-1")
+  })
 })
 
 describe("PUT /team-schedules/teams/[teamId]/schedule", () => {

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/schedule/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse, after } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { schedules, teamDayStatus, teamMembers, teams, users } from "@/app/_domains/teamSchedules/_server/schema"
 import { getSessionUserId, getTeamMembershipWithSuspension } from "@/app/_domains/teamSchedules/_server/authz"
+import { isTeamVisibleTo } from "@/app/_domains/teamSchedules/_server/shares"
 import { maybeNotifyActivityReached } from "@/app/_domains/teamSchedules/_server/notify"
 import { isDayKey, isScheduleStatus, isUuid, isValidNote } from "@/app/_domains/teamSchedules/_server/validators"
 import type { LolRoleFlags, ScheduleEntry, TeamDayStatusEntry, TeamSchedule, TeamScheduleMember } from "@/app/_domains/teamSchedules/types"
@@ -12,7 +13,8 @@ type RouteContext = { params: Promise<{ teamId: string }> }
 
 /**
  * GET /api/web/team-schedules/teams/[teamId]/schedule?from=&to=
- * 期間内の schedules + members（グリッド描画用・public read）。
+ * 期間内の schedules + members（グリッド描画用）。
+ * 閲覧できるのは所属チーム ∪ 共有相手チームのみ（#175・可視性ガードは下記）。
  */
 export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
   const t = new ServerTiming()
@@ -27,6 +29,21 @@ export async function GET(req: NextRequest, ctx: RouteContext): Promise<NextResp
     const to = req.nextUrl.searchParams.get("to")
     if (!isDayKey(from) || !isDayKey(to)) {
       return NextResponse.json({ success: false, error: "期間の指定が不正です" }, { status: 400 })
+    }
+
+    // 可視性ガード（#175・public read を廃止）: 未ログイン / 所属でも共有でもないチームは存在を隠して 404。
+    // 読み取りなので suspend とは独立（suspend 中でも閲覧は透過）。
+    const userId = await t.measure("session", () => getSessionUserId(req))
+    if (!userId) {
+      const res = NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+      t.applyTo(res)
+      return res
+    }
+    const visible = await t.measure("db_visible", () => isTeamVisibleTo(teamId, userId))
+    if (!visible) {
+      const res = NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+      t.applyTo(res)
+      return res
     }
 
     const teamRows = await t.measure("db_team", () =>

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/share-invite/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/share-invite/route.ts
@@ -36,8 +36,8 @@ export async function POST(req: NextRequest, ctx: RouteContext): Promise<NextRes
     }
 
     const token = await createShareToken(teamId)
-    // share= で受諾フロー（確認画面）に着地。from= は発行元チーム（確認画面の表示・取り違え検知に使う）
-    const url = `${APP_URL}/team_schedules?share=${token}&from=${encodeURIComponent(teamId)}`
+    // share= で受諾フロー（確認画面）に着地。発行元チームは token から解決するので URL には載せない。
+    const url = `${APP_URL}/team_schedules?share=${token}`
     const expiryDays = Math.round(SHARE_TTL / (60 * 60 * 24))
     return NextResponse.json({ success: true, url, expiryDays })
   } catch (error) {

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/share-invite/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/share-invite/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getSessionUserId, getTeamMembershipWithSuspension } from "@/app/_domains/teamSchedules/_server/authz"
+import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
+import { createShareToken, SHARE_TTL } from "@/app/_domains/teamSchedules/_server/shares"
+import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
+import { APP_URL } from "@/app/_server/lib/env"
+
+type RouteContext = { params: Promise<{ teamId: string }> }
+
+/**
+ * POST /api/web/team-schedules/teams/[teamId]/share-invite
+ * 他チームとスケジュールを相互共有するための招待リンクを発行する（要ログイン + admin・#175）。
+ * invite/route.ts と同型。トークンを Redis に TTL付きで保存し、受諾用URLを返す。
+ */
+export async function POST(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  try {
+    const { teamId } = await ctx.params
+    if (!isUuid(teamId)) {
+      return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+    }
+
+    const userId = await getSessionUserId(req)
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    // 利用停止判定とロール取得を1クエリにまとめる（#166・DB往復削減）。suspend→403 を先に判定する
+    const { suspended, teamRole } = await getTeamMembershipWithSuspension(teamId, userId)
+    if (suspended) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
+    }
+
+    // admin（master/admin）でなければ存在を隠して 404（非メンバーもロール不足も同じ扱い）
+    if (teamRole === null || !hasAdminAuthority(teamRole)) {
+      return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+    }
+
+    const token = await createShareToken(teamId)
+    // share= で受諾フロー（確認画面）に着地。from= は発行元チーム（確認画面の表示・取り違え検知に使う）
+    const url = `${APP_URL}/team_schedules?share=${token}&from=${encodeURIComponent(teamId)}`
+    const expiryDays = Math.round(SHARE_TTL / (60 * 60 * 24))
+    return NextResponse.json({ success: true, url, expiryDays })
+  } catch (error) {
+    console.error("team-schedules share-invite POST error:", error)
+    return NextResponse.json({ success: false, error: "共有リンクの発行に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/teams/[teamId]/shares/[partnerTeamId]/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/[teamId]/shares/[partnerTeamId]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getSessionUserId, getTeamMembershipWithSuspension } from "@/app/_domains/teamSchedules/_server/authz"
+import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
+import { deleteShare } from "@/app/_domains/teamSchedules/_server/shares"
+import { isUuid } from "@/app/_domains/teamSchedules/_server/validators"
+
+type RouteContext = { params: Promise<{ teamId: string; partnerTeamId: string }> }
+
+/**
+ * DELETE /api/web/team-schedules/teams/[teamId]/shares/[partnerTeamId]
+ * teamId と partnerTeamId のスケジュール共有を解除する（#175）。
+ * 要ログイン + suspend不可 + [teamId] の admin。片側 admin 単独で実行でき、1行削除で両者から見えなくなる。
+ * 共有が存在しなくても冪等に 200。
+ */
+export async function DELETE(req: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  try {
+    const { teamId, partnerTeamId } = await ctx.params
+    if (!isUuid(teamId) || !isUuid(partnerTeamId)) {
+      return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+    }
+
+    const userId = await getSessionUserId(req)
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "ログインが必要です" }, { status: 401 })
+    }
+
+    // 利用停止判定とロール取得を1クエリに（suspend→403 を先に）
+    const { suspended, teamRole } = await getTeamMembershipWithSuspension(teamId, userId)
+    if (suspended) {
+      return NextResponse.json({ success: false, error: "アカウントが利用停止中のため、この操作はできません" }, { status: 403 })
+    }
+    // 解除を実行する側（teamId）の admin 以上でなければ存在を隠して 404
+    if (teamRole === null || !hasAdminAuthority(teamRole)) {
+      return NextResponse.json({ success: false, error: "チームが見つかりません" }, { status: 404 })
+    }
+
+    await deleteShare(teamId, partnerTeamId)
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error("team-schedules share DELETE error:", error)
+    return NextResponse.json({ success: false, error: "スケジュール共有の解除に失敗しました" }, { status: 500 })
+  }
+}

--- a/my-app/app/api/web/team-schedules/teams/route.test.ts
+++ b/my-app/app/api/web/team-schedules/teams/route.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 import { GET, POST } from "./route"
 import { createTestRequest } from "@/__tests__/helpers/api-test-utils"
 
+import { teams as teamsTable, teamMembers as teamMembersTable } from "@/app/_domains/teamSchedules/_server/schema"
+
 // 認可ヘルパーをモック（未ログイン401・権限なし403・作成成功 のロジックを route 単体で検証する）
 const mockGetSessionUserId = vi.fn()
 const mockCanCreateTeam = vi.fn()
@@ -12,15 +14,30 @@ vi.mock("@/app/_domains/teamSchedules/_server/authz", () => ({
   isUserSuspended: (...args: unknown[]) => mockIsUserSuspended(...args),
 }))
 
+// 共有相手の引き当てはモック（#175・GET の可視チーム集合の組み立てを route 単体で検証する）
+const mockGetSharePartnersForTeams = vi.fn()
+vi.mock("@/app/_domains/teamSchedules/_server/shares", () => ({
+  getSharePartnersForTeams: (...args: unknown[]) => mockGetSharePartnersForTeams(...args),
+}))
+
 // DB は実接続しない。
 // - POST: db.insert(teams).values().returning() → [team]、続けて db.insert(teamMembers).values() を await
-// - GET : db.select().from() → 行配列
+// - GET : db.select().from(table).where() → table の identity で行を出し分ける（thenable チェーン）
 const TEAM = { teamId: "123e4567-e89b-42d3-a456-426614174000", name: "Aチーム", description: null, requiredCount: 5, managementMode: "members" }
+const PARTNER = { teamId: "223e4567-e89b-42d3-a456-426614174111", name: "Bチーム", description: null, requiredCount: 5, managementMode: "members" }
 const insertReturning = vi.fn(async () => [TEAM])
 const insertValues = vi.fn(() => ({ returning: insertReturning, then: (r: (v: undefined) => void) => r(undefined) }))
 const insert = vi.fn((..._a: unknown[]) => ({ values: insertValues }))
-const selectFrom = vi.fn(async () => [] as unknown[])
-const select = vi.fn((..._a: unknown[]) => ({ from: selectFrom }))
+// table identity → 返す行。GET 内の teamMembers / teams の SELECT を出し分ける
+const selectResults = new Map<unknown, unknown[]>()
+function makeSelectQuery(rows: unknown[]) {
+  const q: Record<string, unknown> = {
+    where: () => q,
+    then: (resolve: (v: unknown[]) => unknown) => resolve(rows),
+  }
+  return q
+}
+const select = vi.fn((..._a: unknown[]) => ({ from: (table: unknown) => makeSelectQuery(selectResults.get(table) ?? []) }))
 vi.mock("@/app/_server/lib/db", () => ({
   db: {
     select: (...args: unknown[]) => select(...args),
@@ -34,20 +51,50 @@ const validBody = { name: "Aチーム", description: null, managementMode: "memb
 beforeEach(() => {
   vi.clearAllMocks()
   insertReturning.mockResolvedValue([TEAM])
-  selectFrom.mockResolvedValue([])
+  selectResults.clear()
+  mockGetSharePartnersForTeams.mockResolvedValue(new Map())
   // デフォルトは利用停止でない（個別テストで上書き）
   mockIsUserSuspended.mockResolvedValue(false)
 })
 
 describe("GET /team-schedules/teams", () => {
-  it("success: チーム一覧を返す（未ログインは isMember:false）", async () => {
-    // 未ログイン（getSessionUserId 未モック→undefined）なので所属チーム照会は走らず全て isMember:false
+  it("success: 未ログインは空配列を返す（public read 廃止・#175）", async () => {
     mockGetSessionUserId.mockResolvedValue(null)
-    selectFrom.mockResolvedValue([TEAM])
     const res = await GET(createTestRequest(URL))
     const json = await res.json()
     expect(res.status).toBe(200)
-    expect(json.teams).toEqual([{ ...TEAM, isMember: false, isMaster: false }])
+    expect(json.teams).toEqual([])
+    // 未ログインなら所属・共有の照会は一切走らない
+    expect(mockGetSharePartnersForTeams).not.toHaveBeenCalled()
+  })
+
+  it("success: ログイン中は 所属 ∪ 共有相手 のみ返し、所属チームに sharedTeamIds を付与する（#175）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    // user-1 は TEAM の master として所属
+    selectResults.set(teamMembersTable, [{ teamId: TEAM.teamId, teamRole: "master" }])
+    // TEAM は PARTNER と共有している
+    mockGetSharePartnersForTeams.mockResolvedValue(new Map([[TEAM.teamId, [PARTNER.teamId]]]))
+    // 可視チーム（所属 ∪ 共有相手）= TEAM, PARTNER
+    selectResults.set(teamsTable, [TEAM, PARTNER])
+
+    const res = await GET(createTestRequest(URL))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.teams).toEqual([
+      { ...TEAM, isMember: true, isMaster: true, sharedTeamIds: [PARTNER.teamId] },
+      // 共有相手として可視なだけのチームは非所属・sharedTeamIds は空
+      { ...PARTNER, isMember: false, isMaster: false, sharedTeamIds: [] },
+    ])
+  })
+
+  it("success: どのチームにも所属せず共有も無ければ空配列（可視チーム0件）", async () => {
+    mockGetSessionUserId.mockResolvedValue("user-1")
+    selectResults.set(teamMembersTable, [])
+    mockGetSharePartnersForTeams.mockResolvedValue(new Map())
+    const res = await GET(createTestRequest(URL))
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.teams).toEqual([])
   })
 })
 

--- a/my-app/app/api/web/team-schedules/teams/route.ts
+++ b/my-app/app/api/web/team-schedules/teams/route.ts
@@ -1,20 +1,48 @@
-import { eq } from "drizzle-orm"
+import { eq, inArray } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
 import { db } from "@/app/_server/lib/db"
 import { teamMembers, teams } from "@/app/_domains/teamSchedules/_server/schema"
 import { canCreateTeam, getSessionUserId, isUserSuspended } from "@/app/_domains/teamSchedules/_server/authz"
+import { getSharePartnersForTeams } from "@/app/_domains/teamSchedules/_server/shares"
 import { isManagementMode, isValidRequiredCount, isValidTeamDescription, isValidTeamName } from "@/app/_domains/teamSchedules/_server/validators"
 import type { TeamSummary } from "@/app/_domains/teamSchedules/types"
 import { ServerTiming } from "@/app/_server/lib/serverTiming"
 
 /**
  * GET /api/web/team-schedules/teams
- * チーム一覧（比較セレクタ用・public read）。
- * ログイン中なら、各チームに「自分が所属しているか」(isMember) を付与する（未ログインは全て false）。
+ * 比較セレクタ用のチーム一覧。閲覧できるのは「所属チーム ∪ それと共有しているチーム」だけ（#175）。
+ * 未ログインは何も返さない（teams: []）。各チームに isMember / isMaster / sharedTeamIds を付与する。
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const t = new ServerTiming()
   try {
+    // 未ログインは可視チーム 0 件（public read を廃止・#175）
+    const userId = await t.measure("session", () => getSessionUserId(req))
+    if (!userId) {
+      const res = NextResponse.json({ success: true, teams: [] })
+      t.applyTo(res)
+      return res
+    }
+
+    // 所属チームとロール
+    const memberRows = await t.measure("db_member_teams", () =>
+      db.select({ teamId: teamMembers.teamId, teamRole: teamMembers.teamRole }).from(teamMembers).where(eq(teamMembers.userId, userId)),
+    )
+    const roleByTeam = new Map<string, string>()
+    for (const r of memberRows) roleByTeam.set(r.teamId, r.teamRole)
+    const ownTeamIds = [...roleByTeam.keys()]
+
+    // 所属チームごとの共有相手（1往復）。可視チーム = 所属 ∪ 共有相手
+    const partnersByTeam = await t.measure("db_share_partners", () => getSharePartnersForTeams(ownTeamIds))
+    const visibleIds = new Set(ownTeamIds)
+    for (const partners of partnersByTeam.values()) for (const p of partners) visibleIds.add(p)
+
+    if (visibleIds.size === 0) {
+      const res = NextResponse.json({ success: true, teams: [] })
+      t.applyTo(res)
+      return res
+    }
+
     const rows = await t.measure("db_teams", () =>
       db
         .select({
@@ -24,20 +52,18 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
           requiredCount: teams.requiredCount,
           managementMode: teams.managementMode,
         })
-        .from(teams),
+        .from(teams)
+        .where(inArray(teams.teamId, [...visibleIds])),
     )
 
-    // ログイン中ユーザーの所属チームとロールを引く（未ログインなら空＝全て isMember/isMaster:false）
-    const userId = await t.measure("session", () => getSessionUserId(req))
-    const roleByTeam = new Map<string, string>()
-    if (userId) {
-      const memberRows = await t.measure("db_member_teams", () =>
-        db.select({ teamId: teamMembers.teamId, teamRole: teamMembers.teamRole }).from(teamMembers).where(eq(teamMembers.userId, userId)),
-      )
-      for (const r of memberRows) roleByTeam.set(r.teamId, r.teamRole)
-    }
-
-    const list: TeamSummary[] = rows.map((r) => ({ ...r, isMember: roleByTeam.has(r.teamId), isMaster: roleByTeam.get(r.teamId) === "master" }))
+    const list: TeamSummary[] = rows.map((r) => ({
+      ...r,
+      isMember: roleByTeam.has(r.teamId),
+      isMaster: roleByTeam.get(r.teamId) === "master",
+      // sharedTeamIds は所属チームにのみ実体が入る（partnersByTeam は ownTeamIds で引いたため）。
+      // 共有相手として可視なだけのチームは空配列（その共有相手は呼び出し元には関係ない）。
+      sharedTeamIds: partnersByTeam.get(r.teamId) ?? [],
+    }))
     const res = NextResponse.json({ success: true, teams: list })
     t.applyTo(res)
     return res

--- a/my-app/app/developers/team-schedules/_components/SharesSection.tsx
+++ b/my-app/app/developers/team-schedules/_components/SharesSection.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import type { AdminShare } from "@/app/_domains/teamSchedules/types"
+import { formatDateTime } from "../_utils"
+
+type Props = {
+  shares: AdminShare[]
+}
+
+/** ③ チーム間スケジュール共有のペア一覧（#175・閲覧専用） */
+export function SharesSection({ shares }: Props) {
+  return (
+    <section>
+      <h2 className="mb-1 text-lg font-bold">スケジュール共有（{shares.length}）</h2>
+      <p className="mb-3 text-xs text-zinc-400">どのチームとどのチームが互いの活動可能日を共有しているか。共有は対称（双方向）です。</p>
+      {shares.length === 0 ? (
+        <p className="text-sm text-zinc-400">共有しているチームはありません。</p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-zinc-700 bg-zinc-900/60">
+          <table className="w-full min-w-[480px] border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-zinc-700 text-left text-xs text-zinc-400">
+                <th className="px-3 py-2 font-medium">チーム</th>
+                <th className="px-3 py-2 font-medium">チーム</th>
+                <th className="px-3 py-2 font-medium">共有開始</th>
+              </tr>
+            </thead>
+            <tbody>
+              {shares.map((s) => (
+                <tr key={`${s.teamLow.teamId}:${s.teamHigh.teamId}`} className="border-b border-zinc-800 align-top">
+                  <td className="px-3 py-2 text-zinc-200">{s.teamLow.name}</td>
+                  <td className="px-3 py-2 text-zinc-200">{s.teamHigh.name}</td>
+                  <td className="px-3 py-2 text-zinc-300">{formatDateTime(s.createdAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/my-app/app/developers/team-schedules/_components/TeamSchedulesAdminPage.tsx
+++ b/my-app/app/developers/team-schedules/_components/TeamSchedulesAdminPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/app/_client/lib/apiClient/teamSchedulesAdmin"
 import { TeamsSection } from "./TeamsSection"
 import { OrphanUsersSection } from "./OrphanUsersSection"
+import { SharesSection } from "./SharesSection"
 import { DiscordBanSection } from "./DiscordBanSection"
 
 /**
@@ -121,6 +122,7 @@ export function TeamSchedulesAdminPage() {
         <div className="space-y-10">
           <TeamsSection teams={overview.teams} onDeleteTeam={handleDeleteTeam} onRemoveMember={handleRemoveMember} onToggleSuspend={handleToggleSuspend} />
           <OrphanUsersSection users={overview.orphanUsers} onDeleteUser={handleDeleteUser} onToggleSuspend={handleToggleSuspend} />
+          <SharesSection shares={overview.shares} />
           <DiscordBanSection bans={bans} onAddBan={handleAddBan} onRemoveBan={handleRemoveBan} />
         </div>
       ) : null}

--- a/my-app/app/team_schedules/_components/InviteModal.tsx
+++ b/my-app/app/team_schedules/_components/InviteModal.tsx
@@ -5,12 +5,19 @@ import { useState } from "react"
 type InviteModalProps = {
   url: string
   expiryDays: number
+  /** リンクの用途。invite=チーム参加（既定） / share=スケジュール相互共有（#175）。見出し・説明文だけ切り替える */
+  variant?: "invite" | "share"
   onClose: () => void
 }
 
-/** 発行済みの招待リンクを表示し、コピーできるモーダル */
-export function InviteModal({ url, expiryDays, onClose }: InviteModalProps) {
+/** 発行済みの招待／共有リンクを表示し、コピーできるモーダル */
+export function InviteModal({ url, expiryDays, variant = "invite", onClose }: InviteModalProps) {
   const [copied, setCopied] = useState(false)
+  const isShare = variant === "share"
+  const title = isShare ? "スケジュール共有リンク" : "招待リンク"
+  const description = isShare
+    ? "このリンクを相手チームの管理者に渡すと、リンクを踏んで承認した時点で互いのスケジュールを共有できます。"
+    : "このリンクを渡すと、ログインした人がこのチームに参加できます。"
 
   const handleCopy = async () => {
     try {
@@ -24,10 +31,8 @@ export function InviteModal({ url, expiryDays, onClose }: InviteModalProps) {
 
   return (
     <div className="w-[min(92vw,460px)] rounded-xl border border-zinc-700 bg-zinc-900 p-6 text-zinc-100 shadow-xl">
-      <h2 className="text-base font-bold text-zinc-100">招待リンク</h2>
-      <p className="mt-2 text-sm leading-relaxed text-zinc-300">
-        このリンクを渡すと、ログインした人がこのチームに参加できます。
-      </p>
+      <h2 className="text-base font-bold text-zinc-100">{title}</h2>
+      <p className="mt-2 text-sm leading-relaxed text-zinc-300">{description}</p>
 
       <div className="mt-3 flex items-stretch gap-2">
         <input readOnly value={url} className="min-w-0 flex-1 rounded border border-zinc-600 bg-zinc-800 px-2.5 py-1.5 text-xs text-zinc-200" />

--- a/my-app/app/team_schedules/_components/SettingModal.tsx
+++ b/my-app/app/team_schedules/_components/SettingModal.tsx
@@ -50,6 +50,12 @@ type SettingModalProps = {
   onCreated: (team: TeamSummary) => void
   /** 招待リンク発行（親が createInvite → 招待モーダル表示まで担当） */
   onInvite: () => void
+  /** このチームがスケジュールを共有している相手チーム（teamId + 名前・#175） */
+  sharePartners: { teamId: string; name: string }[]
+  /** 共有リンク発行（親が createShareInvite → 共有モーダル表示まで担当・#175） */
+  onShareInvite: () => void
+  /** 共有解除の確認モーダルを開く（親が overlay で確認 → deleteShare を叩く・#175） */
+  onUnshare: (partnerTeamId: string, partnerName: string) => void
   /** 現在のタブ（URL クエリ `?setting=<tab>` 由来。親が単一の真実として持つ） */
   tab: SettingTab
   /** タブ切替（親が URL クエリを書き換える） */
@@ -94,7 +100,7 @@ function ComingSoonSection({ title }: { title: string }) {
  * タブ構成: 今のチーム（設定変更・招待リンク発行）/ 新規チーム作成 / 全体設定（準備中）。
  * md 以下は body 全体を覆う実質ページ、lg 以上は中央カード。
  */
-export function SettingModal({ isLoggedIn, onLogin, team, isAdmin, isMember, isMaster, canCreate, onClose, onUpdated, onCreated, onInvite, onLeave, onSucceed, onDisband, onLogout, onDeleteAccount, tab, onTabChange }: SettingModalProps) {
+export function SettingModal({ isLoggedIn, onLogin, team, isAdmin, isMember, isMaster, canCreate, onClose, onUpdated, onCreated, onInvite, sharePartners, onShareInvite, onUnshare, onLeave, onSucceed, onDisband, onLogout, onDeleteAccount, tab, onTabChange }: SettingModalProps) {
   // タブの選択状態は URL クエリ（?setting=<tab>）を単一の真実とし、親から tab/onTabChange で受け取る
   // 編集項目はモーダル末尾の「保存する」1つでまとめて保存する（変更のあった項目だけ1回の PATCH で送る）
   // team 未選択（null）でもフックは固定数呼ぶ必要があるため、初期値はフォールバックで持つ（チーム管理タブは team が無ければ案内のみ）
@@ -244,6 +250,40 @@ export function SettingModal({ isLoggedIn, onLogin, team, isAdmin, isMember, isM
               <button type="button" onClick={onInvite} className="mt-2 rounded-lg border border-indigo-500 bg-zinc-900 px-3 py-1.5 text-sm font-medium text-indigo-300 hover:bg-zinc-800">
                 招待リンクを発行
               </button>
+            </section>
+          )}
+
+          {/* スケジュール共有（admin のみ・#175）。相手チームと互いの活動可能日を共有する。発行・解除の確認は親に委譲 */}
+          {isAdmin && (
+            <section className="border-t border-zinc-800 pt-4">
+              <h3 className="text-sm font-bold text-zinc-300">スケジュール共有</h3>
+              <p className="mt-1 text-xs text-zinc-500">他チームと互いの活動可能日を共有します。共有リンクを相手チームの管理者に渡し、承認されると相手のスケジュールを比較できます。</p>
+              <button type="button" onClick={onShareInvite} className="mt-2 rounded-lg border border-indigo-500 bg-zinc-900 px-3 py-1.5 text-sm font-medium text-indigo-300 hover:bg-zinc-800">
+                スケジュールを共有する
+              </button>
+
+              {/* 共有中のチーム一覧（0件でも見出しは出す）。各行に解除ボタン */}
+              <div className="mt-3">
+                <h4 className="text-xs font-bold text-zinc-400">共有中のチーム</h4>
+                {sharePartners.length === 0 ? (
+                  <p className="mt-1 text-xs text-zinc-500">まだ共有しているチームはありません。</p>
+                ) : (
+                  <ul className="mt-1.5 flex flex-col gap-1.5">
+                    {sharePartners.map((p) => (
+                      <li key={p.teamId} className="flex items-center justify-between gap-2 rounded border border-zinc-700 bg-zinc-800/50 px-2.5 py-1.5">
+                        <span className="min-w-0 flex-1 truncate text-sm text-zinc-200">{p.name}</span>
+                        <button
+                          type="button"
+                          onClick={() => onUnshare(p.teamId, p.name)}
+                          className="shrink-0 rounded border border-rose-700 bg-rose-950/40 px-2 py-1 text-xs font-medium text-rose-300 hover:bg-rose-900/40"
+                        >
+                          共有を解除する
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
             </section>
           )}
 

--- a/my-app/app/team_schedules/_components/ShareAcceptModal.tsx
+++ b/my-app/app/team_schedules/_components/ShareAcceptModal.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useState } from "react"
+import type { SharePreview } from "@/app/_domains/teamSchedules/types"
+
+type ShareAcceptModalProps = {
+  preview: SharePreview
+  /** 受諾処理。自分の所属チーム（acceptTeamId）と発行元チームを共有する。成功で自動的に閉じる */
+  onAccept: (acceptTeamId: string) => Promise<void>
+  onClose: () => void
+}
+
+/**
+ * 共有リンク着地時の確認モーダル（#175）。
+ * 発行元チームと、受諾者の所属チーム（admin 以上）を相互共有してよいか確認する。
+ * 共有は対称かつ非推移であることを図で説明する。
+ */
+export function ShareAcceptModal({ preview, onAccept, onClose }: ShareAcceptModalProps) {
+  const { sourceTeam, acceptCandidates } = preview
+  // 候補が1件なら自動選択、複数なら最初を初期選択、0件は空（受諾不可）
+  const [acceptTeamId, setAcceptTeamId] = useState<string>(acceptCandidates[0]?.teamId ?? "")
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const noCandidate = acceptCandidates.length === 0
+
+  const handleAccept = async () => {
+    if (submitting || !acceptTeamId) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await onAccept(acceptTeamId)
+      onClose()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "共有の開始に失敗しました")
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="w-[min(92vw,460px)] rounded-xl border border-zinc-700 bg-zinc-900 p-6 text-zinc-100 shadow-xl">
+      <h2 className="text-base font-bold text-zinc-100">スケジュールを共有しますか？</h2>
+      <p className="mt-2 text-sm leading-relaxed text-zinc-300">
+        チーム「{sourceTeam.name}」と、互いの活動可能日を共有します。共有すると、両チームの管理者・メンバーが相手のスケジュールを閲覧できるようになります。
+      </p>
+
+      {/* 共有は対称かつ非推移であることの説明＋図 */}
+      <div className="mt-3 rounded-lg border border-zinc-700 bg-zinc-800/50 p-3 text-xs leading-relaxed text-zinc-400">
+        <div className="flex items-center justify-center gap-1 py-1 font-mono text-sm text-zinc-300" aria-hidden>
+          <span className="rounded bg-zinc-700 px-1.5 py-0.5">A</span>
+          <span className="text-emerald-400">↔</span>
+          <span className="rounded bg-zinc-700 px-1.5 py-0.5">B</span>
+          <span className="text-emerald-400">↔</span>
+          <span className="rounded bg-zinc-700 px-1.5 py-0.5">C</span>
+        </div>
+        <p className="mt-2">
+          共有は<span className="text-zinc-200">相手ごとに個別</span>です。A–B と B–C を共有しても、<span className="text-zinc-200">A と C は共有されません</span>（A から C のスケジュールは見えません）。
+        </p>
+        <p className="mt-1.5">2チーム目以降は、チーム設定からいつでも追加で共有できます。</p>
+      </div>
+
+      {noCandidate ? (
+        <p className="mt-4 rounded-lg border border-amber-700 bg-amber-950/40 px-3 py-2 text-xs text-amber-300">
+          共有を結べるチームがありません。共有するには、あなたが管理者（master / admin）のチームが必要です。
+        </p>
+      ) : acceptCandidates.length === 1 ? (
+        <p className="mt-4 text-sm text-zinc-300">
+          あなたのチーム「{acceptCandidates[0].name}」と共有します。
+        </p>
+      ) : (
+        <label className="mt-4 block text-sm">
+          <span className="text-zinc-400">共有する自分のチーム</span>
+          <select
+            value={acceptTeamId}
+            onChange={(e) => setAcceptTeamId(e.target.value)}
+            className="mt-1 w-full rounded border border-zinc-600 bg-zinc-800 px-2 py-1.5 font-medium text-zinc-100 focus:border-indigo-400 focus:outline-none"
+          >
+            {acceptCandidates.map((t) => (
+              <option key={t.teamId} value={t.teamId}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {error && <p className="mt-3 text-xs text-rose-400">{error}</p>}
+
+      <div className="mt-5 flex justify-end gap-2">
+        <button type="button" onClick={onClose} disabled={submitting} className="rounded-lg border border-zinc-600 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-800 disabled:opacity-50">
+          {noCandidate ? "閉じる" : "キャンセル"}
+        </button>
+        {!noCandidate && (
+          <button
+            type="button"
+            onClick={handleAccept}
+            disabled={submitting || !acceptTeamId}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? "処理中…" : "共有する"}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
+++ b/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
@@ -10,6 +10,8 @@ type TeamCompareSelectorProps = {
   opponentTeamIds: string[];
   onOwnTeamChange: (teamId: string | null) => void;
   onOpponentsChange: (teamIds: string[]) => void;
+  /** 共有0件のチームを自チーム選択中に「他チームと共有する」導線を押したとき（設定の共有セクションを開く・#175） */
+  onOpenShareSetting?: () => void;
 };
 
 /** ラベル列の幅（自チーム / 相手チームで揃える。「相手チーム」4文字が収まる幅） */
@@ -22,6 +24,7 @@ export function TeamCompareSelector({
   opponentTeamIds,
   onOwnTeamChange,
   onOpponentsChange,
+  onOpenShareSetting,
 }: TeamCompareSelectorProps) {
   const toggleOpponent = (teamId: string) => {
     if (opponentTeamIds.includes(teamId)) {
@@ -31,11 +34,17 @@ export function TeamCompareSelector({
     }
   }
 
-  // 自チームは「自分が所属しているチーム」だけから選べる（相手チームは全チームが候補）
+  // 自チームは「自分が所属しているチーム」だけから選べる
   const ownTeamCandidates = teams.filter((t) => t.isMember)
 
-  // 自チームに選ばれているチームは相手候補から除外
-  const opponentCandidates = teams.filter((t) => t.teamId !== ownTeamId)
+  // 相手チームは「選択中の自チームがスケジュールを共有している相手」だけが候補（#175）。
+  // 自チーム未選択なら候補なし。共有0件なら候補なし＋共有導線を出す。
+  const ownTeam = teams.find((t) => t.teamId === ownTeamId) ?? null
+  const sharedIds = new Set(ownTeam?.sharedTeamIds ?? [])
+  const opponentCandidates = teams.filter((t) => sharedIds.has(t.teamId))
+
+  // 自チーム選択済みで共有が0件のとき、相手チーム欄に共有導線を出す
+  const showShareCta = ownTeam !== null && opponentCandidates.length === 0 && !!onOpenShareSetting
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm">
@@ -82,12 +91,22 @@ export function TeamCompareSelector({
         >
           相手チーム
         </span>
-        <OpponentDropdown
-          candidates={opponentCandidates}
-          selectedIds={opponentTeamIds}
-          onToggle={toggleOpponent}
-          className="min-w-0 flex-1"
-        />
+        {showShareCta ? (
+          <button
+            type="button"
+            onClick={onOpenShareSetting}
+            className="min-w-0 flex-1 rounded border border-indigo-500 bg-indigo-500/15 px-2 py-1 text-left text-xs font-medium text-indigo-300 transition-colors hover:bg-indigo-500/25"
+          >
+            他チームとスケジュールを共有する
+          </button>
+        ) : (
+          <OpponentDropdown
+            candidates={opponentCandidates}
+            selectedIds={opponentTeamIds}
+            onToggle={toggleOpponent}
+            className="min-w-0 flex-1"
+          />
+        )}
       </div>
 
       {/* md以上: ピル（チップ）一覧（従来表示） */}
@@ -101,7 +120,17 @@ export function TeamCompareSelector({
         </span>
         <div className="flex flex-1 flex-wrap items-center gap-2">
           {opponentCandidates.length === 0 ? (
-            <span className="pt-1 text-xs text-zinc-500">候補がありません</span>
+            showShareCta ? (
+              <button
+                type="button"
+                onClick={onOpenShareSetting}
+                className="rounded-full border border-indigo-500 bg-indigo-500/15 px-2.5 py-1 text-xs font-medium text-indigo-300 transition-colors hover:bg-indigo-500/25"
+              >
+                他チームとスケジュールを共有する
+              </button>
+            ) : (
+              <span className="pt-1 text-xs text-zinc-500">候補がありません</span>
+            )
           ) : (
             opponentCandidates.map((t) => {
               const checked = opponentTeamIds.includes(t.teamId)

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -182,7 +182,7 @@ export function TeamSchedulesPage() {
     } catch {
       // sessionStorage が使えない環境ではこの後の受諾処理が走らないだけ
     }
-    // share / from を消す。team= は持たないリンクなので素のパスへ戻る
+    // share を消す。team= は持たないリンクなので素のパスへ戻る
     cleanUrlKeepingTeam()
   }, [shareToken, cleanUrlKeepingTeam])
 

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -7,12 +7,16 @@ import { useOverlay } from "@/app/_client/lib/modal/ModalContext"
 import type { ScheduleEntry, ScheduleStatus, SessionUser, TeamSchedule, TeamSummary } from "@/app/_domains/teamSchedules/types"
 import { hasAdminAuthority } from "@/app/_domains/teamSchedules/types"
 import {
+  acceptShare,
   createInvite,
+  createShareInvite,
   deleteAccount,
   deleteSchedule,
+  deleteShare,
   deleteTeamStatus,
   disbandTeam,
   fetchSession,
+  fetchSharePreview,
   fetchTeamSchedule,
   fetchTeams,
   joinTeam,
@@ -39,6 +43,7 @@ import { CreateTeamRestrictedModal } from "./CreateTeamRestrictedModal"
 import { DbHealthButton } from "./DbHealthButton"
 import { InviteModal } from "./InviteModal"
 import { LoginModal } from "./LoginModal"
+import { ShareAcceptModal } from "./ShareAcceptModal"
 import { ScheduleDayCards } from "./ScheduleDayCards"
 import { ScheduleGrid } from "./ScheduleGrid"
 import { ScheduleHelpModal } from "./ScheduleHelpModal"
@@ -52,6 +57,9 @@ const NUM_DAYS = 14
 
 /** 招待リンクからの参加トークンを、ログイン往復をまたいで保持する sessionStorage キー */
 const PENDING_JOIN_KEY = "ts_pending_join"
+
+/** 共有リンクからの共有トークンを、ログイン往復をまたいで保持する sessionStorage キー（#175） */
+const PENDING_SHARE_KEY = "ts_pending_share"
 
 export function TeamSchedulesPage() {
   const { open, close } = useOverlay()
@@ -164,6 +172,20 @@ export function TeamSchedulesPage() {
     cleanUrlKeepingTeam()
   }, [joinToken, cleanUrlKeepingTeam])
 
+  // 共有リンク着地: ?share= があれば共有トークンを sessionStorage に退避し、URLを掃除する（#175）。
+  // join と同型。受諾の確認モーダルはログイン確立後（下の effect）に開く。
+  const shareToken = searchParams.get("share")
+  useEffect(() => {
+    if (!shareToken) return
+    try {
+      window.sessionStorage.setItem(PENDING_SHARE_KEY, shareToken)
+    } catch {
+      // sessionStorage が使えない環境ではこの後の受諾処理が走らないだけ
+    }
+    // share / from を消す。team= は持たないリンクなので素のパスへ戻る
+    cleanUrlKeepingTeam()
+  }, [shareToken, cleanUrlKeepingTeam])
+
   // 初期ロード: セッション + チーム一覧
   useEffect(() => {
     let cancelled = false
@@ -186,7 +208,7 @@ export function TeamSchedulesPage() {
 
   // 初期ロード直後に1回だけ、復元した選択を整合させる。
   // - 自チーム: 所属チーム（isMember）以外（削除済み・別デバイスで脱退した残り等）は null に倒す。
-  // - 相手チーム: チーム一覧（public read で全チーム返す）に存在しない＝削除済みのみ取り除く。
+  // - 相手チーム: 可視チーム一覧（所属 ∪ 共有相手・#175）に無い ID（削除済み・共有解除済み等）を取り除く。
   // 以降の参加・作成では意図的に有効なチームを選択するため、再実行しない（選択が消されるのを防ぐ）。
   // 例外: magic-link ログイン確立後の再取得時のみ reconciledRef を戻し、もう一度だけ走らせる（上の宣言箇所参照）。
   useEffect(() => {
@@ -359,6 +381,60 @@ export function TeamSchedulesPage() {
     }
   }, [loading, session, openLogin, reloadTeams, setOwnTeamId])
 
+  // 退避済みの共有トークンを処理する（#175）。
+  // - 未ログイン: ログイン案内（ログイン後に再実行される）
+  // - ログイン済み: 確認情報を取得して受諾モーダルを開く。受諾成功で一覧を取り直し相手候補に反映。
+  // モーダルを開く時点で退避を消す（キャンセル時は破棄＝再度リンクを踏めばやり直せる。join とは異なり確認ダイアログのため）。
+  useEffect(() => {
+    if (loading) return
+    let pending: string | null = null
+    try {
+      pending = window.sessionStorage.getItem(PENDING_SHARE_KEY)
+    } catch {
+      pending = null
+    }
+    if (!pending) return
+
+    if (!session) {
+      openLogin()
+      return
+    }
+
+    const token = pending
+    let cancelled = false
+    void fetchSharePreview(token)
+      .then((preview) => {
+        if (cancelled) return
+        try {
+          window.sessionStorage.removeItem(PENDING_SHARE_KEY)
+        } catch {
+          // 失敗しても致命的ではない
+        }
+        open(
+          <ShareAcceptModal
+            preview={preview}
+            onClose={close}
+            onAccept={async (acceptTeamId) => {
+              await acceptShare(token, acceptTeamId)
+              // 共有相手が増えるので一覧を取り直す（sharedTeamIds 更新で相手候補に出る）
+              void reloadTeams()
+            }}
+          />,
+        )
+      })
+      .catch(() => {
+        // 失効・無効トークン等。退避を消して諦める
+        try {
+          window.sessionStorage.removeItem(PENDING_SHARE_KEY)
+        } catch {
+          // noop
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [loading, session, openLogin, open, close, reloadTeams])
+
   // セルの状態トグル
   const handleCycle = useCallback(
     ({ teamId, userId, day, current }: { teamId: string; userId: string; day: string; current: CellStatus }) => {
@@ -497,12 +573,52 @@ export function TeamSchedulesPage() {
     }
   }, [ownTeamId, open, close])
 
+  // 共有リンクを発行して表示する（#175・招待リンクと同型）
+  const handleShareInvite = useCallback(async () => {
+    if (!ownTeamId) return
+    try {
+      const { url, expiryDays } = await createShareInvite(ownTeamId)
+      open(<InviteModal url={url} expiryDays={expiryDays} variant="share" onClose={close} />)
+    } catch {
+      // 発行失敗時は何もしない（権限喪失など）
+    }
+  }, [ownTeamId, open, close])
+
+  // 共有を解除する（#175）。両者から見えなくなる旨を確認してから 1行削除し、一覧を取り直す。
+  const handleUnshare = useCallback(
+    (partnerTeamId: string, partnerName: string) => {
+      if (!ownTeamId) return
+      const teamId = ownTeamId
+      open(
+        <ConfirmModal
+          title="スケジュール共有を解除"
+          description={`「${partnerName}」とのスケジュール共有を解除します。\n解除すると、両チームから互いのスケジュールが見えなくなります。`}
+          confirmLabel="共有を解除する"
+          onConfirm={async () => {
+            await deleteShare(teamId, partnerTeamId)
+            void reloadTeams()
+          }}
+          onClose={close}
+        />,
+      )
+    },
+    [ownTeamId, open, close, reloadTeams],
+  )
+
   // 選択中の自チームのメンバーか（チーム管理画面はメンバーなら開ける）
   const isOwnMember = useMemo(() => {
     if (!session || !ownTeamId) return false
     const ownTeam = schedulesByTeam[ownTeamId]
     return !!ownTeam?.members.some((m) => m.userId === session.userId)
   }, [session, ownTeamId, schedulesByTeam])
+
+  // 選択中の自チームの共有相手（teamId + 名前）。teams 一覧の sharedTeamIds から名前を解決する（#175）
+  const sharePartners = useMemo(() => {
+    if (!ownTeamId) return []
+    const ids = teams.find((t) => t.teamId === ownTeamId)?.sharedTeamIds ?? []
+    const nameById = new Map(teams.map((t) => [t.teamId, t.name]))
+    return ids.map((id) => ({ teamId: id, name: nameById.get(id) ?? "(不明なチーム)" }))
+  }, [ownTeamId, teams])
 
   // 設定モーダルの開閉・タブ選択は URL クエリ（?setting=<tab>）で管理する。
   // open() の命令的呼び出しではなく派生値でインライン描画することで、保存後の再取得で
@@ -691,9 +807,11 @@ export function TeamSchedulesPage() {
     const ownTeam = ownTeamId ? schedulesByTeam[ownTeamId] : undefined
     if (!ownTeam) return null
 
-    // 自チームに選んだチームは相手チームの表示から必ず除外する（同一チームの二重表示を防ぐ）
+    // 相手チームは「自チームと共有しているチーム」だけを表示する（#175）。
+    // 自チーム自身は除外し、別の自チームを選んでいた頃の stale な選択もここで弾く（共有外のグリッド表示を防ぐ）。
+    const sharedSet = new Set(teams.find((t) => t.teamId === ownTeamId)?.sharedTeamIds ?? [])
     const opponents = opponentTeamIds
-      .filter((id) => id !== ownTeamId)
+      .filter((id) => id !== ownTeamId && sharedSet.has(id))
       .map((id) => schedulesByTeam[id])
       .filter((t): t is TeamSchedule => !!t)
     const ownIndexed = indexSchedules(ownTeam.schedules)
@@ -802,7 +920,7 @@ export function TeamSchedulesPage() {
     // team モードは単一状態（ok=活動可能）なので閾値は 1
     const threshold = ownTeam.managementMode === "team" ? 1 : ownTeam.requiredCount
     return { memberColumns, opponentColumns, rows, threshold, managementMode: ownTeam.managementMode, ownTeamName: ownTeam.name }
-  }, [ownTeamId, opponentTeamIds, schedulesByTeam, dates, dayKeys, session])
+  }, [ownTeamId, opponentTeamIds, schedulesByTeam, dates, dayKeys, session, teams])
 
   // 自分が1つでもチームに所属しているか（teams 一覧の isMember 由来）。md以下で「チームを作成」ボタンを隠す判定に使う。
   const belongsToAnyTeam = useMemo(() => teams.some((t) => t.isMember), [teams])
@@ -931,7 +1049,7 @@ export function TeamSchedulesPage() {
         >
           <div className={"min-h-0 " + (chromeOverflowVisible ? "overflow-visible" : "overflow-hidden")}>
             <div className="flex flex-col md:gap-3 gap-1.5">
-              <TeamCompareSelector teams={teams} ownTeamId={ownTeamId} opponentTeamIds={opponentTeamIds} onOwnTeamChange={setOwnTeamId} onOpponentsChange={setOpponentTeamIds} />
+              <TeamCompareSelector teams={teams} ownTeamId={ownTeamId} opponentTeamIds={opponentTeamIds} onOwnTeamChange={setOwnTeamId} onOpponentsChange={setOpponentTeamIds} onOpenShareSetting={openManage} />
               {view && <ControlBar threshold={view.threshold} managementMode={view.managementMode} />}
             </div>
           </div>
@@ -1024,6 +1142,9 @@ export function TeamSchedulesPage() {
                 onUpdated={handleManageUpdated}
                 onCreated={handleTeamCreatedInModal}
                 onInvite={() => void handleInvite()}
+                sharePartners={sharePartners}
+                onShareInvite={() => void handleShareInvite()}
+                onUnshare={handleUnshare}
                 onLeave={handleLeaveRequest}
                 onSucceed={handleSuccessionRequest}
                 onDisband={handleDisbandRequest}

--- a/my-app/drizzle/0006_foamy_slayback.sql
+++ b/my-app/drizzle/0006_foamy_slayback.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "team_shares" (
+	"team_low" uuid NOT NULL,
+	"team_high" uuid NOT NULL,
+	"created_by" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "team_shares_team_low_team_high_pk" PRIMARY KEY("team_low","team_high"),
+	CONSTRAINT "team_shares_order_chk" CHECK ("team_shares"."team_low" < "team_shares"."team_high")
+);
+--> statement-breakpoint
+ALTER TABLE "team_shares" ADD CONSTRAINT "team_shares_team_low_teams_team_id_fk" FOREIGN KEY ("team_low") REFERENCES "public"."teams"("team_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_shares" ADD CONSTRAINT "team_shares_team_high_teams_team_id_fk" FOREIGN KEY ("team_high") REFERENCES "public"."teams"("team_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "team_shares" ADD CONSTRAINT "team_shares_created_by_users_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("user_id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_team_shares_high" ON "team_shares" USING btree ("team_high");

--- a/my-app/drizzle/meta/0006_snapshot.json
+++ b/my-app/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,818 @@
+{
+  "id": "b5ad6131-b50e-4989-921e-700d245f2734",
+  "prevId": "24f0306d-7f39-426a-942a-1dddc3fedb5a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.discord_bans": {
+      "name": "discord_bans",
+      "schema": "",
+      "columns": {
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_links": {
+      "name": "discord_links",
+      "schema": "",
+      "columns": {
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_links_user": {
+          "name": "idx_discord_links_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_links_user_id_users_user_id_fk": {
+          "name": "discord_links_user_id_users_user_id_fk",
+          "tableFrom": "discord_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule_notifications": {
+      "name": "schedule_notifications",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'activity_reached'"
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_notifications_team_id_teams_team_id_fk": {
+          "name": "schedule_notifications_team_id_teams_team_id_fk",
+          "tableFrom": "schedule_notifications",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "schedule_notifications_team_id_day_kind_pk": {
+          "name": "schedule_notifications_team_id_day_kind_pk",
+          "columns": [
+            "team_id",
+            "day",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_schedules_team_day": {
+          "name": "idx_schedules_team_day",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_team_member_fk": {
+          "name": "schedules_team_member_fk",
+          "tableFrom": "schedules",
+          "tableTo": "team_members",
+          "columnsFrom": [
+            "team_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "team_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "schedules_team_id_user_id_day_pk": {
+          "name": "schedules_team_id_user_id_day_pk",
+          "columns": [
+            "team_id",
+            "user_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "schedules_status_chk": {
+          "name": "schedules_status_chk",
+          "value": "\"schedules\".\"status\" in ('ok', 'maybe', 'ng')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_day_status": {
+      "name": "team_day_status",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_day_status_team_id_teams_team_id_fk": {
+          "name": "team_day_status_team_id_teams_team_id_fk",
+          "tableFrom": "team_day_status",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_day_status_team_id_day_pk": {
+          "name": "team_day_status_team_id_day_pk",
+          "columns": [
+            "team_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_day_status_status_chk": {
+          "name": "team_day_status_status_chk",
+          "value": "\"team_day_status\".\"status\" in ('ok', 'maybe', 'ng')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "top": {
+          "name": "top",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "jungle": {
+          "name": "jungle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mid": {
+          "name": "mid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "adc": {
+          "name": "adc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "support": {
+          "name": "support",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_team_members_one_master": {
+          "name": "uq_team_members_one_master",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_members\".\"team_role\" = 'master'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_team_members_user": {
+          "name": "idx_team_members_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_team_id_fk": {
+          "name": "team_members_team_id_teams_team_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_user_id_fk": {
+          "name": "team_members_user_id_users_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_invited_by_users_user_id_fk": {
+          "name": "team_members_invited_by_users_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_team_id_user_id_pk": {
+          "name": "team_members_team_id_user_id_pk",
+          "columns": [
+            "team_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_members_team_role_chk": {
+          "name": "team_members_team_role_chk",
+          "value": "\"team_members\".\"team_role\" in ('master', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_shares": {
+      "name": "team_shares",
+      "schema": "",
+      "columns": {
+        "team_low": {
+          "name": "team_low",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_high": {
+          "name": "team_high",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_team_shares_high": {
+          "name": "idx_team_shares_high",
+          "columns": [
+            {
+              "expression": "team_high",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_shares_team_low_teams_team_id_fk": {
+          "name": "team_shares_team_low_teams_team_id_fk",
+          "tableFrom": "team_shares",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_low"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_shares_team_high_teams_team_id_fk": {
+          "name": "team_shares_team_high_teams_team_id_fk",
+          "tableFrom": "team_shares",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_high"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_shares_created_by_users_user_id_fk": {
+          "name": "team_shares_created_by_users_user_id_fk",
+          "tableFrom": "team_shares",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_shares_team_low_team_high_pk": {
+          "name": "team_shares_team_low_team_high_pk",
+          "columns": [
+            "team_low",
+            "team_high"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_shares_order_chk": {
+          "name": "team_shares_order_chk",
+          "value": "\"team_shares\".\"team_low\" < \"team_shares\".\"team_high\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.team_webhooks": {
+      "name": "team_webhooks",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discord'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notify_activity_reached": {
+          "name": "notify_activity_reached",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_webhooks_team_id_teams_team_id_fk": {
+          "name": "team_webhooks_team_id_teams_team_id_fk",
+          "tableFrom": "team_webhooks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "team_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_webhooks_team_id_slot_pk": {
+          "name": "team_webhooks_team_id_slot_pk",
+          "columns": [
+            "team_id",
+            "slot"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "team_webhooks_slot_chk": {
+          "name": "team_webhooks_slot_chk",
+          "value": "\"team_webhooks\".\"slot\" in ('own', 'shared')"
+        },
+        "team_webhooks_provider_chk": {
+          "name": "team_webhooks_provider_chk",
+          "value": "\"team_webhooks\".\"provider\" in ('discord')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_count": {
+          "name": "required_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "management_mode": {
+          "name": "management_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'members'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "teams_required_count_chk": {
+          "name": "teams_required_count_chk",
+          "value": "\"teams\".\"required_count\" >= 1"
+        },
+        "teams_management_mode_chk": {
+          "name": "teams_management_mode_chk",
+          "value": "\"teams\".\"management_mode\" in ('members', 'team')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended": {
+          "name": "suspended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/my-app/drizzle/meta/_journal.json
+++ b/my-app/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1782061283783,
       "tag": "0005_dear_may_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1782137351810,
+      "tag": "0006_foamy_slayback",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

スクリム調整機能（`/team_schedules`）で、他チームのスケジュール（活動可能日）を閲覧するには**両チームの相互共有（合意）が必要**にする。旧来の全チーム public read（誰でも全チームのスケジュールを閲覧可）を廃止する。

導入後の不変条件: **ログイン中ユーザーが読めるスケジュール = 自分の所属チーム ∪ その所属チームと共有しているチーム**。共有は対称（A↔B）かつ**非推移**（A-B・B-C があっても A-C は見えない）。

## このPRで対応する issue

- #175

## 変更点

### DB
- `team_shares` テーブル追加（1共有=1行・順序づけペア `team_low < team_high`・CHECK で自己共有禁止・FK cascade）
- マイグレーション `0006_foamy_slayback.sql`

### サーバー（`_server/shares.ts`）
- `orderPair` / `getSharePartners` / `getSharePartnersForTeams` / `getUserTeamIds` / `deleteShare` / `createShareToken`
- 可視判定の純粋関数 `isTeamVisible`（**核心の非推移をここで担保**）と、その合成 `isTeamVisibleTo`（直接所属は即 true、それ以外は対象の直接共有相手のみ1ホップ照会）

### API
| パス | メソッド | 概要 |
| --- | --- | --- |
| `teams/[teamId]/share-invite` | POST | 共有リンク発行（admin） |
| `shares/preview?token=` | GET | 受諾確認画面用の情報 |
| `shares` | POST | 受諾＝相互共有を成立（admin・自己共有400・冪等） |
| `teams/[teamId]/shares/[partnerTeamId]` | DELETE | 共有解除（片側 admin・冪等） |

- `teams` GET: public read 廃止、可視チームのみ返却（`sharedTeamIds` 付与・未ログインは空）
- `teams/[teamId]/schedule` GET: 可視性ガード（未ログイン・非可視は存在隠蔽 404）
- `admin/overview` GET: 共有ペア一覧 `shares` を追加

### フロント
- 相手チーム候補を共有相手のみに絞り込み、共有0件時は「他チームと共有する」導線を表示
- 共有リンク着地 → 確認モーダル `ShareAcceptModal`（非推移の図解付き）→ 受諾
- チーム設定に「スケジュール共有」セクション（発行・共有中一覧・解除）
- 管理画面に共有ペア一覧 `SharesSection`

## テスト
- `npx tsc --noEmit` / `npm run lint` クリア、`vitest run` **258 passed**
- 追加: `orderPair`・`getSharePartnersForTeams` の振り分け、`teams` GET の可視性絞り込み、`schedule` GET の可視性ガード（404）
- **核心の非推移不変条件**を `isTeamVisible`（純粋関数・A-B-C で A→C 不可視）と `isTeamVisibleTo`（DB 合成）で検証

## 補足
- 共有リンクは招待リンクと同型（7日 TTL・受諾後も TTL 失効まで有効）。issue「展望」の返事待ち承認・URL 1回使い切り等は対象外（MVP）。
- 本番 Neon へのマイグレーション適用（`0006`）はデプロイ時に必要。
- 手動 E2E（A-B 共有→相互可視 / B-C でも A→C 不可視 / 解除で双方から消える）は別途実機確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)