### PR TITLE
fix: /team_schedules UI バグ修正＋通知説明文のブラッシュアップ（#206）

### DIFF
--- a/my-app/app/developers/team-schedules/_components/DiscordBanSection.tsx
+++ b/my-app/app/developers/team-schedules/_components/DiscordBanSection.tsx
@@ -60,7 +60,7 @@ export function DiscordBanSection({ bans, onAddBan, onRemoveBan }: Props) {
               value={discordUserId}
               onChange={(e) => setDiscordUserId(e.target.value)}
               placeholder="例: 123456789012345678"
-              className="w-64 rounded-md border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-sm text-zinc-100"
+              className="w-full sm:w-64 rounded-md border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-sm text-zinc-100"
             />
           </label>
           <label className="flex flex-1 flex-col gap-1 text-xs text-zinc-400">

--- a/my-app/app/developers/team-schedules/_components/TeamSchedulesAdminPage.tsx
+++ b/my-app/app/developers/team-schedules/_components/TeamSchedulesAdminPage.tsx
@@ -100,7 +100,7 @@ export function TeamSchedulesAdminPage() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl p-6 text-zinc-100">
+    <div className="mx-auto w-full min-w-0 max-w-5xl overflow-x-hidden p-4 text-zinc-100 sm:p-6">
       <header className="mb-6 flex items-center justify-between gap-4">
         <h1 className="text-2xl font-bold">スクリム調整 管理画面</h1>
         <button

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -213,20 +213,22 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, ownColumns, own
             >
               日付
             </th>
-            {/* 相手チーム: 2段ぶち抜き・ピン留め・相手セレクタの選択中チップと同色（amber） */}
+            {/* 相手チーム: 2段ぶち抜き・ピン留め・相手セレクタの選択中チップと同色（amber）。
+                sticky なので背景は不透明にする（半透明だと縦スクロール時に下を通る行が透ける）。行背景に近い不透明の amber ティント。 */}
             {opponentColumns.map((c, i) => (
               <th
                 key={`opp:${c.teamId}`}
                 rowSpan={2}
-                className={HEADER_BASE + " text-center align-middle bg-amber-500/15 text-amber-300"}
+                className={HEADER_BASE + " text-center align-middle bg-[#3a2e10] text-amber-300"}
                 style={{ position: "sticky", left: SIZE.date + i * SIZE.opponent, top: 0, zIndex: 30, minWidth: SIZE.opponent, width: SIZE.opponent }}
               >
                 {c.label}
               </th>
             ))}
-            {/* 自チーム: 上段にチーム名（○数〜各メンバーをまたぐ）。自分の色（indigo）で目立たせ、はみ出しは title で全文表示 */}
+            {/* 自チーム: 上段にチーム名（○数〜各メンバーをまたぐ）。自分の色（indigo）で目立たせ、はみ出しは title で全文表示。
+                sticky なので背景は不透明にする（半透明だと縦スクロール時に下を通る行が透ける）。行背景に近い不透明の indigo ティント。 */}
             {ownGrouped ? (
-              <th colSpan={ownLeaves.length} className="border-b border-r border-zinc-700 px-2 text-left bg-indigo-500/15" style={{ position: "sticky", top: 0, zIndex: 20, height: OWN_NAME_H }}>
+              <th colSpan={ownLeaves.length} className="border-b border-r border-zinc-700 px-2 text-left bg-[#1e213a]" style={{ position: "sticky", top: 0, zIndex: 20, height: OWN_NAME_H }}>
                 {/*
                   colSpan セル自体への sticky-left は border-collapse 下で効かないことがあるため、
                   ラベル（span）を sticky-left で固定する。セルは幅が広く背景は残るので、横スクロールしても

--- a/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
+++ b/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
@@ -47,9 +47,9 @@ export function TeamCompareSelector({
   const showShareCta = ownTeam !== null && opponentCandidates.length === 0 && !!onOpenShareSetting
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm">
+    <div className="flex w-full min-w-0 flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm">
       {/* md未満: 自作ドロップダウン（下向きに展開・幅いっぱい） */}
-      <div className="flex items-center gap-2 md:hidden">
+      <div className="flex w-full min-w-0 items-center gap-2 md:hidden">
         <span
           className={LABEL_WIDTH + " shrink-0 whitespace-nowrap text-zinc-400"}
         >
@@ -64,7 +64,7 @@ export function TeamCompareSelector({
       </div>
 
       {/* md以上: ネイティブ select（従来表示） */}
-      <label className="hidden items-center gap-2 md:flex">
+      <label className="hidden w-full min-w-0 items-center gap-2 md:flex">
         <span
           className={LABEL_WIDTH + " shrink-0 whitespace-nowrap text-zinc-400"}
         >
@@ -85,7 +85,7 @@ export function TeamCompareSelector({
       </label>
 
       {/* md未満: チェックボックス式ドロップダウン（空きスペースいっぱいに広げる） */}
-      <div className="flex items-center gap-2 md:hidden">
+      <div className="flex w-full min-w-0 items-center gap-2 md:hidden">
         <span
           className={LABEL_WIDTH + " shrink-0 whitespace-nowrap text-zinc-400"}
         >
@@ -110,7 +110,7 @@ export function TeamCompareSelector({
       </div>
 
       {/* md以上: ピル（チップ）一覧（従来表示） */}
-      <div className="hidden items-start gap-2 md:flex">
+      <div className="hidden w-full min-w-0 items-start gap-2 md:flex">
         <span
           className={
             LABEL_WIDTH + " shrink-0 whitespace-nowrap pt-1 text-zinc-400"

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -1022,7 +1022,7 @@ export function TeamSchedulesPage() {
           <div className="flex min-w-0 flex-1 items-start md:gap-2">
             <div className="min-w-0">
               <h1 className="text-lg font-bold tracking-tight text-zinc-100">チーム活動 スケジュール調整</h1>
-              <p className="mt-0.5 text-sm text-zinc-400">メンバーの参加可能日から、スクリム相手を探す</p>
+              <p className={"mt-0.5 text-sm text-zinc-400" + (chromeCollapsed ? " hidden md:block" : "")}>メンバーの参加可能日から、スクリム相手を探す</p>
             </div>
             {/* md以下: 設定をタイトル右に置いて縦スペースを節約する（md以上は右側のボタン群に表示）。
                 ml-auto で右端へ寄せ、タイトル側の幅を確保する。

--- a/my-app/app/team_schedules/_components/WebhookSettingsSection.test.tsx
+++ b/my-app/app/team_schedules/_components/WebhookSettingsSection.test.tsx
@@ -30,6 +30,15 @@ describe("WebhookSettingsSection", () => {
     })
   })
 
+  it("success: 通知が1回だけ届く旨の補足文を表示する", async () => {
+    mockFetch.mockResolvedValue({ webhooks: [], notifyTime: null })
+    render(<WebhookSettingsSection teamId={TEAM_ID} isMaster={true} />)
+    await waitFor(() => {
+      // 「活動可能になった日」につき1回だけ送られる旨の補足文（2通知ではなくタイミング違いである説明）
+      expect(screen.getByText(/「活動可能になった日」につき1回だけ送られます/)).toBeTruthy()
+    })
+  })
+
   it("failure: 取得失敗でもクラッシュせずエラー表示する", async () => {
     mockFetch.mockRejectedValue(new Error("通信失敗"))
     render(<WebhookSettingsSection teamId={TEAM_ID} isMaster={false} />)

--- a/my-app/app/team_schedules/_components/WebhookSettingsSection.tsx
+++ b/my-app/app/team_schedules/_components/WebhookSettingsSection.tsx
@@ -208,6 +208,12 @@ export function WebhookSettingsSection({ teamId, isMaster }: { teamId: string; i
           {/* 送信タイミング（#177）。即時 or 指定時刻 */}
           <div className="rounded-lg border border-zinc-800 p-3">
             <span className="text-sm font-medium text-zinc-200">通知タイミング</span>
+            <p className="mt-1 text-xs leading-relaxed text-zinc-500">
+              通知は「活動可能になった日」につき1回だけ送られます。届くタイミングだけを選べます。
+              <br />
+              <span className="text-zinc-300">「すぐに通知」</span>は条件が揃った瞬間に、
+              <span className="text-zinc-300">「指定した時刻に通知」</span>はその活動可能になった当日の指定時刻に、同じ通知が届きます。
+            </p>
             <div className="mt-2 flex flex-col gap-2">
               <label className="flex items-center gap-2 text-sm text-zinc-300">
                 <input type="radio" name="notify-timing" checked={!scheduled} onChange={() => updateScheduled(false)} disabled={saving} className="h-4 w-4 accent-indigo-500" />


### PR DESCRIPTION
## 関連 issue
- #206

## 概要
`/team_schedules`（および管理画面 `/developers/team-schedules`）の UI バグ4件を修正し、通知タイミング説明文をブラッシュアップ（計5件）。すべてフロントのレイアウト/文面変更で、ロジック・API・データは触っていない。

## 変更内容（バグ別 (1)〜(5)）
- **(1) sticky ヘッダーが透ける** — `ScheduleGrid.tsx`
  2段ヘッダーの sticky `<th>` のうち半透明だった2つ（相手 `bg-amber-500/15` / 自チーム `bg-indigo-500/15`）を不透明近似色 `bg-[#3a2e10]` / `bg-[#1e213a]` に置換。文字色 `text-amber-300`/`text-indigo-300` は据え置き（相手=amber・自=indigo の「セレクタ選択中チップと同色」の意味付けを維持）。縦スクロール時にヘッダー下を行が透けて見える問題を解消。
- **(2) 管理画面がスマホで横幅暴走** — `DiscordBanSection.tsx` / `TeamSchedulesAdminPage.tsx`
  はみ出し源の BAN 追加フォーム Discord ID 入力を固定幅 `w-64` → `w-full sm:w-64`（スマホ親幅いっぱい・sm 以上で従来 256px）。さらにページルートに `w-full min-w-0 overflow-x-hidden p-4 ... sm:p-6` を付与して二重防御（将来別の子が溢れた時の保険／テーブルは各自 `overflow-x-auto` 内に横スクロールが閉じる）。
- **(3) 折りたたみ時にサブ見出しも隠す** — `TeamSchedulesPage.tsx`
  タイトル直下のサブ見出し `<p>`（折りたたみ領域の外にあるため従来は畳んでも残っていた）に、`chromeCollapsed` 時のみ `hidden md:block` を条件付与。md 未満で折りたたんだ時だけ隠れ、md 以上は従来どおり表示。隣接コード（同ファイルの grid 行）と同じ `"base " + (cond ? " ..." : "")` 連結パターンに統一。
- **(4) セレクタが md 以下で見切れ** — `TeamCompareSelector.tsx`
  ルート＋各行に `w-full min-w-0` を付与し `min-w-0` の連鎖を端まで通すことで親幅内に収める。折りたたみ inner の `overflow-visible`（#156 都合）は触らず、セレクタ側を親幅に収める方針で副作用を回避。
- **(5) 通知タイミング説明文のブラッシュアップ** — `WebhookSettingsSection.tsx` / `.test.tsx`
  「通知タイミング」セクション冒頭に補足文を1つ追加。本文 `text-zinc-500`、`「」` 内モード名のみ `text-zinc-300` で少し明るく強調。「通知は1回だけ届く旨」を確認する success テストを1件追加。

## 仕様・トレードオフ
- **(1) なぜ不透明「近似色」か**: 半透明ティントの色味を厳密に保つには th に疑似要素で不透明 underlay を敷く必要があるが、border-collapse + sticky では `::before` の絶対配置がボーダーとズレやすく複雑化する。厳密合成色との微差はごく僅かで、**実機での見え方を優先**し solid 近似色（zinc-900 土台に amber/indigo を約15%重ねた色）を採用。
- **(4) md 以上(67/113)にも `min-w-0` を入れた一貫性判断**: 主因は md 未満だが、「md 未満だけ直して md 以上はバラバラ」を避けるため全4行で `w-full min-w-0` を統一。md 以上の行は `hidden md:flex` の表示トグルで、`w-full min-w-0` は flex-column 子に対し幅を変えず（列方向で実質 no-op）min-width だけ緩めるため、デスクトップ表示は退行しない。
- **(5) 「2通知」ではなく「1通知×2モード」と確定した根拠**: `notify.ts`（5-19 / 267-289）・`schema.ts`・`types.ts` を裏取りし、通知イベントは「ある日が活動可能になった立ち上がりエッジ」の**1種類のみ**で、`notifyActivityTime`（null=即時 / "HH:MM"=当日指定時刻）は**届くタイミングを切り替えるだけ・通知の中身は同一**であることを確認。文面は「1回だけ」「同じ通知が届きます」と明記し、2つの別通知という誤認を排除。モード名は指定時刻側をラジオラベルと完全一致「指定した時刻に通知」、即時側はラベルが長いため補足文では短縮「すぐに通知」を採用。

## 採らなかった代替案と却下理由
- (1) th に疑似要素で不透明 underlay＋半透明ティスト上載せ → border-collapse + sticky でボーダーとズレやすく複雑化のため却下。`bg-zinc-800` 統一案も amber/indigo の意味付けを失うため却下。
- (2) 専用 `layout.tsx` 新設 → ファイル増。本体 div に枠を集約する既存流儀に合わせ却下。`max-w-64` 案は flex basis が端末差で不安定なため却下。
- (3) `<p>` を折りたたみ領域内へ移動 → アニメーション/overflow 制御が絡み複雑化。要件「md 以下で隠す」だけなら条件クラスが軽量・安全のため却下。`md:hidden` 無条件付与は折りたたんでいない時も消えるため却下。
- (4) 折りたたみ inner を `overflow-x-hidden` 化 → ドロップダウン(absolute)が領域外へ出られず #156 を再発させるため却下。selector ルートに固定 `max-w` 案も端末幅に追従せず却下。
- (5) ラジオラベル自体に説明を盛り込む → ラベルが冗長で一覧性低下のため却下。モード名を有彩色(`text-indigo-300` 等)で強調 → 「リンク/操作可能」の含意で誤認の元のため、無彩色のまま輝度だけ上げる `text-zinc-300` を採用。

## 動作確認
- `npm run lint`: pass（エラー/警告ゼロ）
- `npx tsc --noEmit`: pass（exit 0）
- `npx vitest run WebhookSettingsSection.test.tsx`: 3 passed（既存2 + 追加1）
- **正直な注記**: レイアウト系 (1)(2)(3)(4) は本作業 worktree に依存(node_modules は本体へ symlink)・`.env` が無く、本環境では**実機/ブラウザでの目視確認ができていない**。コード解析・既存テストへの非影響確認・lint/tsc/test は pass 済み。DevTools レスポンシブでの最終目視はレビュア側でお願いしたい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
