### PR TITLE
release: /team_schedules UI バグ修正＋通知説明文ブラッシュアップ（Closes #206）

### DIFF
--- a/my-app/app/developers/team-schedules/_components/DiscordBanSection.tsx
+++ b/my-app/app/developers/team-schedules/_components/DiscordBanSection.tsx
@@ -60,7 +60,7 @@ export function DiscordBanSection({ bans, onAddBan, onRemoveBan }: Props) {
               value={discordUserId}
               onChange={(e) => setDiscordUserId(e.target.value)}
               placeholder="例: 123456789012345678"
-              className="w-64 rounded-md border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-sm text-zinc-100"
+              className="w-full sm:w-64 rounded-md border border-zinc-600 bg-zinc-800 px-2 py-1.5 text-sm text-zinc-100"
             />
           </label>
           <label className="flex flex-1 flex-col gap-1 text-xs text-zinc-400">

--- a/my-app/app/developers/team-schedules/_components/TeamSchedulesAdminPage.tsx
+++ b/my-app/app/developers/team-schedules/_components/TeamSchedulesAdminPage.tsx
@@ -100,7 +100,7 @@ export function TeamSchedulesAdminPage() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl p-6 text-zinc-100">
+    <div className="mx-auto w-full min-w-0 max-w-5xl overflow-x-hidden p-4 text-zinc-100 sm:p-6">
       <header className="mb-6 flex items-center justify-between gap-4">
         <h1 className="text-2xl font-bold">スクリム調整 管理画面</h1>
         <button

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -70,6 +70,17 @@ function pinnedStyle(column: Column<GridRow>, isHeader: boolean): React.CSSPrope
   }
 }
 
+/**
+ * sticky な見出しセルの「チップ同色ティント」を表現する装飾レイヤー。
+ * 背景色そのものを半透明にすると縦スクロール時に下を通る行が透けるため、
+ * 不透明ベース（bg-zinc-900＝グリッド地色）を敷いたセルの上に、この半透明レイヤーを重ねて色味だけ乗せる。
+ * 親セルは sticky（=positioned）なので、これが containing block になり inset-0 でセル全体を覆う。
+ * tintClass には `bg-amber-500/15` のようなセレクタの選択中チップと同色の半透明背景を渡す。
+ */
+function StickyTintOverlay({ tintClass }: { tintClass: string }) {
+  return <span aria-hidden className={"pointer-events-none absolute inset-0 " + tintClass} />
+}
+
 export function ScheduleGrid({ rows, threshold, opponentColumns, ownColumns, ownTeamName, onCycle, onNoteChange, onTeamCycle, onTeamNoteChange, onLoadMore, canLoadMore }: ScheduleGridProps) {
   const columns = useMemo<ColumnDef<GridRow>[]>(() => {
     // 列の種別に応じた編集ハンドラ（表・カード共通の makeCellHandlers に委譲）
@@ -214,21 +225,26 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, ownColumns, own
               日付
             </th>
             {/* 相手チーム: 2段ぶち抜き・ピン留め・相手セレクタの選択中チップと同色（amber）。
-                sticky なので背景は不透明にする（半透明だと縦スクロール時に下を通る行が透ける）。行背景に近い不透明の amber ティント。 */}
+                sticky なので背景は不透明にする（半透明だと縦スクロール時に下を通る行が透ける）。
+                不透明ベース(bg-zinc-900)＋ StickyTintOverlay でチップと同色のティントを保ちつつ不透明化する。 */}
             {opponentColumns.map((c, i) => (
               <th
                 key={`opp:${c.teamId}`}
                 rowSpan={2}
-                className={HEADER_BASE + " text-center align-middle bg-[#3a2e10] text-amber-300"}
+                className={HEADER_BASE + " text-center align-middle bg-zinc-900 text-amber-300"}
                 style={{ position: "sticky", left: SIZE.date + i * SIZE.opponent, top: 0, zIndex: 30, minWidth: SIZE.opponent, width: SIZE.opponent }}
               >
-                {c.label}
+                <StickyTintOverlay tintClass="bg-amber-500/15" />
+                {/* ティントレイヤーより上に出すため relative にする */}
+                <span className="relative">{c.label}</span>
               </th>
             ))}
             {/* 自チーム: 上段にチーム名（○数〜各メンバーをまたぐ）。自分の色（indigo）で目立たせ、はみ出しは title で全文表示。
-                sticky なので背景は不透明にする（半透明だと縦スクロール時に下を通る行が透ける）。行背景に近い不透明の indigo ティント。 */}
+                sticky なので背景は不透明にする（半透明だと縦スクロール時に下を通る行が透ける）。
+                不透明ベース(bg-zinc-900)＋ StickyTintOverlay でチップと同色のティントを保ちつつ不透明化する。 */}
             {ownGrouped ? (
-              <th colSpan={ownLeaves.length} className="border-b border-r border-zinc-700 px-2 text-left bg-[#1e213a]" style={{ position: "sticky", top: 0, zIndex: 20, height: OWN_NAME_H }}>
+              <th colSpan={ownLeaves.length} className="border-b border-r border-zinc-700 px-2 text-left bg-zinc-900" style={{ position: "sticky", top: 0, zIndex: 20, height: OWN_NAME_H }}>
+                <StickyTintOverlay tintClass="bg-indigo-500/15" />
                 {/*
                   colSpan セル自体への sticky-left は border-collapse 下で効かないことがあるため、
                   ラベル（span）を sticky-left で固定する。セルは幅が広く背景は残るので、横スクロールしても

--- a/my-app/app/team_schedules/_components/ScheduleGrid.tsx
+++ b/my-app/app/team_schedules/_components/ScheduleGrid.tsx
@@ -213,20 +213,22 @@ export function ScheduleGrid({ rows, threshold, opponentColumns, ownColumns, own
             >
               日付
             </th>
-            {/* 相手チーム: 2段ぶち抜き・ピン留め・相手セレクタの選択中チップと同色（amber） */}
+            {/* 相手チーム: 2段ぶち抜き・ピン留め・相手セレクタの選択中チップと同色（amber）。
+                sticky なので背景は不透明にする（半透明だと縦スクロール時に下を通る行が透ける）。行背景に近い不透明の amber ティント。 */}
             {opponentColumns.map((c, i) => (
               <th
                 key={`opp:${c.teamId}`}
                 rowSpan={2}
-                className={HEADER_BASE + " text-center align-middle bg-amber-500/15 text-amber-300"}
+                className={HEADER_BASE + " text-center align-middle bg-[#3a2e10] text-amber-300"}
                 style={{ position: "sticky", left: SIZE.date + i * SIZE.opponent, top: 0, zIndex: 30, minWidth: SIZE.opponent, width: SIZE.opponent }}
               >
                 {c.label}
               </th>
             ))}
-            {/* 自チーム: 上段にチーム名（○数〜各メンバーをまたぐ）。自分の色（indigo）で目立たせ、はみ出しは title で全文表示 */}
+            {/* 自チーム: 上段にチーム名（○数〜各メンバーをまたぐ）。自分の色（indigo）で目立たせ、はみ出しは title で全文表示。
+                sticky なので背景は不透明にする（半透明だと縦スクロール時に下を通る行が透ける）。行背景に近い不透明の indigo ティント。 */}
             {ownGrouped ? (
-              <th colSpan={ownLeaves.length} className="border-b border-r border-zinc-700 px-2 text-left bg-indigo-500/15" style={{ position: "sticky", top: 0, zIndex: 20, height: OWN_NAME_H }}>
+              <th colSpan={ownLeaves.length} className="border-b border-r border-zinc-700 px-2 text-left bg-[#1e213a]" style={{ position: "sticky", top: 0, zIndex: 20, height: OWN_NAME_H }}>
                 {/*
                   colSpan セル自体への sticky-left は border-collapse 下で効かないことがあるため、
                   ラベル（span）を sticky-left で固定する。セルは幅が広く背景は残るので、横スクロールしても

--- a/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
+++ b/my-app/app/team_schedules/_components/TeamCompareSelector.tsx
@@ -47,9 +47,9 @@ export function TeamCompareSelector({
   const showShareCta = ownTeam !== null && opponentCandidates.length === 0 && !!onOpenShareSetting
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm">
+    <div className="flex w-full min-w-0 flex-col gap-3 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2.5 text-sm">
       {/* md未満: 自作ドロップダウン（下向きに展開・幅いっぱい） */}
-      <div className="flex items-center gap-2 md:hidden">
+      <div className="flex w-full min-w-0 items-center gap-2 md:hidden">
         <span
           className={LABEL_WIDTH + " shrink-0 whitespace-nowrap text-zinc-400"}
         >
@@ -64,7 +64,7 @@ export function TeamCompareSelector({
       </div>
 
       {/* md以上: ネイティブ select（従来表示） */}
-      <label className="hidden items-center gap-2 md:flex">
+      <label className="hidden w-full min-w-0 items-center gap-2 md:flex">
         <span
           className={LABEL_WIDTH + " shrink-0 whitespace-nowrap text-zinc-400"}
         >
@@ -85,7 +85,7 @@ export function TeamCompareSelector({
       </label>
 
       {/* md未満: チェックボックス式ドロップダウン（空きスペースいっぱいに広げる） */}
-      <div className="flex items-center gap-2 md:hidden">
+      <div className="flex w-full min-w-0 items-center gap-2 md:hidden">
         <span
           className={LABEL_WIDTH + " shrink-0 whitespace-nowrap text-zinc-400"}
         >
@@ -110,7 +110,7 @@ export function TeamCompareSelector({
       </div>
 
       {/* md以上: ピル（チップ）一覧（従来表示） */}
-      <div className="hidden items-start gap-2 md:flex">
+      <div className="hidden w-full min-w-0 items-start gap-2 md:flex">
         <span
           className={
             LABEL_WIDTH + " shrink-0 whitespace-nowrap pt-1 text-zinc-400"

--- a/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
+++ b/my-app/app/team_schedules/_components/TeamSchedulesPage.tsx
@@ -1022,7 +1022,7 @@ export function TeamSchedulesPage() {
           <div className="flex min-w-0 flex-1 items-start md:gap-2">
             <div className="min-w-0">
               <h1 className="text-lg font-bold tracking-tight text-zinc-100">チーム活動 スケジュール調整</h1>
-              <p className="mt-0.5 text-sm text-zinc-400">メンバーの参加可能日から、スクリム相手を探す</p>
+              <p className={"mt-0.5 text-sm text-zinc-400" + (chromeCollapsed ? " hidden md:block" : "")}>メンバーの参加可能日から、スクリム相手を探す</p>
             </div>
             {/* md以下: 設定をタイトル右に置いて縦スペースを節約する（md以上は右側のボタン群に表示）。
                 ml-auto で右端へ寄せ、タイトル側の幅を確保する。

--- a/my-app/app/team_schedules/_components/WebhookSettingsSection.test.tsx
+++ b/my-app/app/team_schedules/_components/WebhookSettingsSection.test.tsx
@@ -30,6 +30,15 @@ describe("WebhookSettingsSection", () => {
     })
   })
 
+  it("success: 通知が1回だけ届く旨の補足文を表示する", async () => {
+    mockFetch.mockResolvedValue({ webhooks: [], notifyTime: null })
+    render(<WebhookSettingsSection teamId={TEAM_ID} isMaster={true} />)
+    await waitFor(() => {
+      // 「活動可能になった日」につき1回だけ送られる旨の補足文（2通知ではなくタイミング違いである説明）
+      expect(screen.getByText(/「活動可能になった日」につき1回だけ送られます/)).toBeTruthy()
+    })
+  })
+
   it("failure: 取得失敗でもクラッシュせずエラー表示する", async () => {
     mockFetch.mockRejectedValue(new Error("通信失敗"))
     render(<WebhookSettingsSection teamId={TEAM_ID} isMaster={false} />)

--- a/my-app/app/team_schedules/_components/WebhookSettingsSection.tsx
+++ b/my-app/app/team_schedules/_components/WebhookSettingsSection.tsx
@@ -208,6 +208,12 @@ export function WebhookSettingsSection({ teamId, isMaster }: { teamId: string; i
           {/* 送信タイミング（#177）。即時 or 指定時刻 */}
           <div className="rounded-lg border border-zinc-800 p-3">
             <span className="text-sm font-medium text-zinc-200">通知タイミング</span>
+            <p className="mt-1 text-xs leading-relaxed text-zinc-500">
+              通知は「活動可能になった日」につき1回だけ送られます。届くタイミングだけを選べます。
+              <br />
+              <span className="text-zinc-300">「すぐに通知」</span>は条件が揃った瞬間に、
+              <span className="text-zinc-300">「指定した時刻に通知」</span>はその活動可能になった当日の指定時刻に、同じ通知が届きます。
+            </p>
             <div className="mt-2 flex flex-col gap-2">
               <label className="flex items-center gap-2 text-sm text-zinc-300">
                 <input type="radio" name="notify-timing" checked={!scheduled} onChange={() => updateScheduled(false)} disabled={saving} className="h-4 w-4 accent-indigo-500" />


### PR DESCRIPTION
## 概要

`/team_schedules`（および管理画面 `/developers/team-schedules`）の UI バグ4件修正＋通知タイミング説明文のブラッシュアップ（計5件）を main へリリースする。すべてフロントのレイアウト/文面変更で、ロジック・API・データは不変。

develop と main の差分は PR #210（feat/eng-tsui）のみ。

## 含まれる変更（PR #210）

- (1) sticky ヘッダーが縦スクロール時に透ける問題を不透明色化で解消（`ScheduleGrid.tsx`）
- (2) 管理画面のスマホ横幅暴走を入力幅 `w-full sm:w-64` ＋ルートの overflow 防御で修正
- (3) 折りたたみ時にサブ見出しも隠す（`chromeCollapsed` 時のみ `hidden md:block`）
- (4) セレクタが md 以下で見切れる問題を `w-full min-w-0` の連鎖で解消
- (5) 通知タイミング説明文を追加（「1回だけ・タイミング違い・中身同一」を明記）＋ success テスト1件追加

## 検証

- CI（lint / typecheck / test / Vercel デプロイ）すべて pass
- レビュー: ブロッカーなしで PR #210 を develop へマージ済み

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
