### PR TITLE
feat(opgg): チーム検索モードで登録チーム一覧を初期表示

### DIFF
--- a/my-app/app/lol/opgg-multi-link/_components/TeamSearchMode.tsx
+++ b/my-app/app/lol/opgg-multi-link/_components/TeamSearchMode.tsx
@@ -52,17 +52,19 @@ export function TeamSearchMode({
         />
       </div>
 
-      {!selected && query.length > 0 && filtered.length > 0 && (
-        <div className="border border-zinc-600 rounded overflow-hidden">
-          {filtered.map((team) => (
-            <button key={team.name} onClick={() => handleSelect(team)} className="w-full text-left px-4 py-2 bg-zinc-800 hover:bg-zinc-700 border-b border-zinc-700 last:border-b-0 text-sm min-w-0">
-              <div className="flex items-baseline min-w-0 overflow-hidden">
-                <span className="font-semibold text-white shrink-0">{team.name}</span>
-                <span className="text-zinc-400 shrink-0 mr-1">({team.members.length}人)：</span>
-                <span className="text-zinc-500 truncate">{team.members.join(", ")}</span>
-              </div>
-            </button>
-          ))}
+      {!selected && filtered.length > 0 && (
+        <div>
+          {query.length === 0 && <p className="text-xs text-zinc-500 mb-1">登録チーム ({filtered.length})</p>}
+          <div className="border border-zinc-600 rounded overflow-hidden max-h-72 overflow-y-auto">
+            {filtered.map((team) => (
+              <button key={team.name} onClick={() => handleSelect(team)} className="w-full text-left px-4 py-2 bg-zinc-800 hover:bg-zinc-700 border-b border-zinc-700 last:border-b-0 text-sm min-w-0">
+                <div className="flex items-baseline min-w-0 overflow-hidden">
+                  <span className="font-semibold text-white shrink-0">{team.name}</span>
+                  <span className="text-zinc-400 shrink-0 ml-1">({team.members.length}人)</span>
+                </div>
+              </button>
+            ))}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## 何を・なぜ

`/lol/opgg-multi-link` の「チーム検索」モードは、検索ボックスに何か入力するまで何も表示されず、ユーザーがどんなチームが登録済みか分からない（正確なチーム名を思い出して打つ必要があった）。

初期状態で登録済みチームを一覧表示し、入力で絞り込むインクリメンタル検索に変更する。

## 変更内容

- 一覧の表示条件から `query.length > 0` を外し、**検索ボックスが空のときは全件表示**（`filtered = teams.filter(...)` は空クエリだと `includes("")` で全件一致）。
- 各行は **「チーム名 + (N人)」** に簡素化。従来あったメンバー名の `join(", ")` 列挙は削除（メンバーは行クリックで選択後に既存の `PlayerListAndUrl` で表示される）。
- 全件表示で縦に伸びるのを防ぐため、一覧に `max-h-72 overflow-y-auto` のスクロール上限を付与。
- **検索が空のときだけ**「登録チーム (N)」の件数見出しを表示。

## トレードオフ・仕様判断

- **行からメンバー名を外したのは UI 簡潔化のためで、DB 負荷削減ではない**。チームデータは Redis の単一キー `lol:opgg:enemy-teams` に全チーム配列（メンバー込み）で保存され、`fetchTeams()` が初期化時に 1 回の GET で全件取得済み。メンバーを行に出す/出さないで DB クエリは増減しない。
- **件数見出しを「空クエリのときだけ」表示する理由**: 絞り込み中は `filtered.length` が一致件数になり、「登録チーム」という見出しと中身が食い違うため。空のとき＝全件なので見出しが正確になる。
- **「見つかりません」案内は `query.length > 0` 条件を維持**。初期（空）状態では全件表示で空一覧にならないため、空のときに誤って「見つかりません」が出ないようにする。登録ゼロ件のときは従来どおり `teams.length === 0` ブロックが「未登録」案内を出す。
- **対象は team-search モードのみ**。「自チーム設定」(`TeamLoginMode` の `TeamSelectForm`) にも類似の検索リストがあるが、今回の要望スコープ外のため変更していない。

## 影響範囲・確認したこと

- 変更ファイルは [TeamSearchMode.tsx](my-app/app/lol/opgg-multi-link/_components/TeamSearchMode.tsx) のみ。
- `npm run lint` / `npx tsc --noEmit` ともにエラー・警告なし。
- 行クリック後の選択挙動（`handleSelect`）・選択後の `PlayerListAndUrl` 表示は変更なし。

## 関連 issue

（なし）